### PR TITLE
ci: add DCO sign-off check (click-to-sign)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,31 @@
+name: DCO Sign-off
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  dco:
+    runs-on: ubuntu-latest
+    steps:
+      - name: DCO sign-off assistant
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the DCO and I hereby sign off on my contribution') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          use-dco-flag: true
+          path-to-signatures: signatures/version1/dco.json
+          path-to-document: https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md
+          branch: dco-signatures
+          allowlist: dependabot[bot],github-actions[bot]
+          custom-pr-sign-comment: I have read the DCO and I hereby sign off on my contribution
+          custom-allsigned-prcomment: All contributors have signed off on their contributions per the DCO. ✍️


### PR DESCRIPTION
Adds **CLA Assistant Lite** running in **DCO mode** so contributors sign off on the Developer Certificate of Origin with a single comment — no `git commit -s` or rebasing required.

## How it works
- On every PR, the workflow posts the DCO text and checks whether each contributor has signed off.
- A contributor signs off **once per PR** by commenting:
  > I have read the DCO and I hereby sign off on my contribution
- The signature is recorded on the isolated **`dco-signatures`** orphan branch in `signatures/version1/dco.json` (GitHub username + PR metadata only — no email).
- Re-runs are triggered by a `recheck` comment.
- Bots (`dependabot[bot]`, `github-actions[bot]`) are allowlisted.

## Follow-up (manual, needs Administration: write)
After this merges and the check runs once, add the resulting status check to the `protect-main` ruleset as a **required** check (UI).

Complements the existing `web_commit_signoff_required` setting, which already auto-signs web-editor commits.