### PR TITLE
fix(packaging): version + copyright in shipped assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,8 +12,8 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Authors>UiPath</Authors>
     <Company>UiPath</Company>
-    <Product>Platform Services</Product>
-    <Copyright>Copyright © UiPath $([System.DateTime]::Now.Year)</Copyright>
+    <Product>UiPath Caching</Product>
+    <Copyright>Copyright © $([System.DateTime]::Now.Year) UiPath, Inc.</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Description>UiPath Caching</Description>
     <PackageTags>Caching</PackageTags>
@@ -24,7 +24,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PackageOutputPath>$(MSBuildThisFileDirectory)Release</PackageOutputPath>
-    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <NoWarn>$(NoWarn);NU5105;NU1507;CS1591;AD0001;NU1900;</NoWarn>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/GlobalAssemblyInfo.cs
+++ b/GlobalAssemblyInfo.cs
@@ -1,11 +1,3 @@
-using System.Reflection;
-using System.Resources;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("UiPath.Caching.Tests")]
-[assembly: AssemblyCompany("UiPath")]
-[assembly: AssemblyProduct("Caching library")]
-[assembly: AssemblyCopyright("Copyright © UiPath $([System.DateTime]::Now.Year)")]
-[assembly: AssemblyTrademark("")]
-[assembly: NeutralResourcesLanguage("en")]
-[assembly: AssemblyCulture("")]

--- a/src/UiPath.Caching.Polly/UiPath.Caching.Polly.csproj
+++ b/src/UiPath.Caching.Polly/UiPath.Caching.Polly.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <Description>A package containing redis executor classes</Description>
+    <Description>Polly resilience pipelines (retry, timeout, circuit breaker) for UiPath.Caching.</Description>
     <PackageTags>UiPath;Caching;Polly</PackageTags>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Pre-release audit found that shipped binaries had no real version or copyright.

## Problem (verified on the release build path: `dotnet build UiPath.Caching.slnx -c Release -p:Version=1.0.0-preview-1`)
`GenerateAssemblyInfo` was `False`, so `/p:Version` only set the **nupkg** version — every DLL shipped as:
- AssemblyVersion / FileVersion: `0.0.0.0`
- InformationalVersion: *(none)*
- LegalCopyright: `Copyright © UiPath $([System.DateTime]::Now.Year)` ← unevaluated MSBuild literal

The compiler even warned `S3904: Provide an 'AssemblyVersion'`, but it was suppressed by `GlobalSuppressions.cs`, so CI looked clean.

## Fix
- Re-enable `GenerateAssemblyInfo` → SDK derives AssemblyVersion/FileVersion/InformationalVersion from `$(Version)` and copyright from `$(Copyright)` (which evaluates the year correctly).
- Trim `GlobalAssemblyInfo.cs` to just `[InternalsVisibleTo]` (removes the now-duplicate, broken attributes).
- Align copyright entity with LICENSE (`UiPath, Inc.`), set `Product` to `UiPath Caching`.
- Fix the inaccurate `UiPath.Caching.Polly` package description.

## After (same build)
| Attribute | Value |
|---|---|
| AssemblyVersion | `1.0.0.0` |
| FileVersion | `1.0.0.0` |
| InformationalVersion | `1.0.0-preview-1+<sha>` |
| LegalCopyright | `Copyright © 2026 UiPath, Inc.` |

S3904 is now genuinely resolved (0 warnings), not suppressed.