### PR TITLE
chore: AwesomeAssertions (MIT) for tests + deterministic CI builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,9 @@
     <LangVersion>12.0</LangVersion>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
     <!-- Test related packages -->
-    <PackageVersion Include="FluentAssertions" Version="8.1.1" />
+    <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit.v3" Version="$(xUnit)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
@@ -73,6 +73,6 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="FluentAssertions.Json" Version="8.0.0" />
+    <PackageVersion Include="AwesomeAssertions.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubSubjectWriterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubSubjectWriterTests.cs
@@ -1,7 +1,6 @@
 using System.Text;
 using System.Text.Json;
 using System.Threading.Channels;
-using FluentAssertions.Extensions;
 using StackExchange.Redis;
 
 namespace UiPath.Caching.Tests.Broadcast;

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubTopicTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubTopicTests.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using FluentAssertions.Extensions;
 using NSubstitute.ExceptionExtensions;
 using StackExchange.Redis;
 using UiPath.Caching.Policies;

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamNotifyChannelTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamNotifyChannelTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Channels;
-using FluentAssertions.Extensions;
 using Microsoft.Extensions.Logging;
 using NSubstitute.ExceptionExtensions;
 using NSubstitute.ReceivedExtensions;

--- a/tests/UiPath.Caching.Tests/Broadcast/SignalingFetchWaiterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/SignalingFetchWaiterTests.cs
@@ -1,4 +1,3 @@
-using FluentAssertions.Extensions;
 
 namespace UiPath.Caching.Tests.Broadcast;
 

--- a/tests/UiPath.Caching.Tests/GlobalUsings.cs
+++ b/tests/UiPath.Caching.Tests/GlobalUsings.cs
@@ -1,6 +1,7 @@
 global using AutoFixture;
 global using AutoFixture.AutoNSubstitute;
-global using FluentAssertions;
+global using AwesomeAssertions;
+global using AwesomeAssertions.Extensions;
 global using Microsoft.Extensions.Options;
 global using NSubstitute;
 global using UiPath.Caching.Broadcast;

--- a/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
+++ b/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
-    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
@@ -25,7 +25,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions.Json" />
+    <PackageReference Include="AwesomeAssertions.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
   </ItemGroup>


### PR DESCRIPTION
Two pre-release audit items.

## #5 — drop commercially-licensed FluentAssertions
FluentAssertions 8.x is under a commercial license (Xceed). It's test-only and never shipped, but a public repo's contributors building tests are technically subject to it. Replaced with **AwesomeAssertions** (MIT fork of FA) in the test project.
- Namespace is `AwesomeAssertions` (not a silent drop-in); updated `using`s accordingly.
- Consolidated the repeated `AwesomeAssertions.Extensions` using into `GlobalUsings.cs`.
- Verified locally: test project builds with 0 warnings, and the non-Redis suites (SignalingFetchWaiter, ResiliencePipelineFactory — 20 tests) pass.

## #7 — deterministic CI package builds
`ContinuousIntegrationBuild=true` under GitHub Actions (`$(GITHUB_ACTIONS) == 'true'`) for reproducible builds + normalized SourceLink paths. Local builds are unaffected.

## Not changed — #6 (MessagePack)
Audited: the `MessagePack` pin is a **deliberate direct reference in the AppHost** to force the patched 2.5.301 over Aspire's vulnerable transitive version — not dead. Left as-is.