### PR TITLE
ci(release): drop nupkg/snupkg assets from GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,3 @@ jobs:
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            packages/*.nupkg
-            packages/*.snupkg


### PR DESCRIPTION
Match the standard .NET OSS convention (FusionCache, Polly, etc.): the GitHub Release is just release notes + GitHub's auto-generated source archives — packages are **not** duplicated as release assets.

- Removes the `files: packages/*.nupkg / *.snupkg` upload from the `Create GitHub Release` step.
- Packages still publish to **nuget.org** via the preceding `Push to nuget.org` step (the canonical `dotnet add package` feed); symbols go to the nuget.org symbol server.
- CI still uploads the `nupkg` workflow artifact for ad-hoc inspection — that's separate from the release.