### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Caching library maintainers — default owners for everything in the repo.
+* @cosmin-staicu @litheon @cosminvlad @alinahornet @lucianaparaschivei @razvalex


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with the caching maintainers as default owners for the repo:
`@cosmin-staicu @litheon @cosminvlad @alinahornet @lucianaparaschivei @razvalex`

## To make it effective (UI, needs Administration access)
1. **Grant these people Write access** — Settings → Collaborators and teams (CODEOWNERS reviewers must have write access for their review to be requested/count).
2. In the `protect-main` ruleset → "Require a pull request before merging": set **Required approvals = 1** and enable **Require review from Code Owners**.

Then every PR auto-requests a review from this group and needs one of them to approve before merge. (Authors can't approve their own PR, so having multiple owners keeps reviews unblocked.)