### PR TITLE
ci(release): gate nuget publish behind opt-in var + protected environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,10 @@ on:
       - 'v*'
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create the GitHub release
-      id-token: write  # OIDC token for nuget.org trusted publishing
     services:
       redis:
         image: redis:7
@@ -50,19 +49,47 @@ jobs:
       - name: Pack
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}
 
-      - name: Authenticate to nuget.org (OIDC trusted publishing)
-        if: vars.NUGET_USER != ''
-        id: nuget-login
-        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+      - name: Upload packages
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          user: ${{ vars.NUGET_USER }}
-
-      - name: Push to nuget.org
-        if: vars.NUGET_USER != ''
-        run: dotnet nuget push 'packages/*.nupkg' --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+          name: nupkg
+          path: |
+            packages/*.nupkg
+            packages/*.snupkg
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           generate_release_notes: true
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # Publishing to nuget.org is gated twice: an explicit opt-in variable AND a
+  # protected environment requiring manual approval. Neither tagging nor having
+  # NUGET_USER set is enough on its own.
+  publish-nuget:
+    needs: release
+    runs-on: ubuntu-latest
+    if: vars.NUGET_USER != '' && vars.PUBLISH_TO_NUGET == 'true'
+    environment: nuget
+    permissions:
+      id-token: write  # OIDC token for nuget.org trusted publishing
+    steps:
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Download packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: nupkg
+          path: packages
+
+      - name: Authenticate to nuget.org (OIDC trusted publishing)
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ vars.NUGET_USER }}
+
+      - name: Push to nuget.org
+        run: dotnet nuget push 'packages/*.nupkg' --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate


### PR DESCRIPTION
Makes publishing to **nuget.org** require a deliberate, two-layer switch — so neither tagging a release nor having `NUGET_USER` configured can publish on its own.

## What changed
`release.yml` is split into two jobs:
- **`release`** — build, test, pack, upload the packages artifact, and create the GitHub **prerelease**. Runs on every `v*` tag. No `id-token` permission.
- **`publish-nuget`** — downloads the artifact and pushes to nuget.org via OIDC. Gated **twice and independently**:
  1. `if: vars.NUGET_USER != '' && vars.PUBLISH_TO_NUGET == 'true'` — explicit opt-in variable.
  2. `environment: nuget` — a **protected environment** (configure Required reviewers → manual approval per release).

Result: tagging produces a GitHub prerelease; nuget.org publish happens only when both the variable is on **and** the environment approval is granted.

## One-time setup to make the environment a hard gate (UI, admin)
**Settings → Environments → New environment `nuget`** → enable **Required reviewers** (add yourself) → optionally restrict deployment branches/tags to `v*`. Scope the nuget.org OIDC trusted-publishing policy to the `nuget` environment too, for a third lock.

Until then: `PUBLISH_TO_NUGET` is unset → the publish job is skipped entirely, and tagging only ever creates a GitHub prerelease.