### PR TITLE
ci: packages only via nuget.org — no downloadable artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,6 @@ jobs:
       - name: Pack
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages
 
-      - name: Upload packages
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: nupkg
-          path: packages/*.nupkg
-
   build-windows:
     runs-on: windows-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,16 +46,8 @@ jobs:
       - name: Test
         run: dotnet test UiPath.Caching.slnx -c Release --no-build
 
-      - name: Pack
+      - name: Pack (validation only — not published or uploaded)
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}
-
-      - name: Upload packages
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: nupkg
-          path: |
-            packages/*.nupkg
-            packages/*.snupkg
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -74,16 +66,24 @@ jobs:
     permissions:
       id-token: write  # OIDC token for nuget.org trusted publishing
     steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 8.0.x
+
       - name: Setup .NET 10
         uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
         with:
           dotnet-version: 10.0.x
 
-      - name: Download packages
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: nupkg
-          path: packages
+      - name: Derive version from tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Pack
+        run: dotnet pack UiPath.Caching.slnx -c Release -o packages /p:Version=${{ steps.version.outputs.value }}
 
       - name: Authenticate to nuget.org (OIDC trusted publishing)
         id: nuget-login


### PR DESCRIPTION
On a **public** repo, GitHub Actions artifacts are downloadable by anyone with read access — which would make the `.nupkg`s a second download source. Goal: packages available **only from nuget.org**.

## Changes
- **`ci.yml`** — remove the `nupkg` artifact upload. `dotnet pack` still runs to validate packaging; nothing is published.
- **`release.yml`** — remove the inter-job `nupkg` artifact entirely:
  - `release` job still packs (validation only) but uploads nothing.
  - `publish-nuget` now checks out the tag and **re-packs** before pushing, instead of downloading an artifact. Deterministic (`ContinuousIntegrationBuild=true`), so the bits match what `release` built/tested, and `needs: release` still gates on tests passing.
- **Test-results** artifact (trx/coverage) is kept — it carries no packages.

Net: no `.nupkg` is ever stored as a downloadable artifact. Release assets already carry no packages (#15). nuget.org is the only distribution channel.

> Supersedes #20 — labeling CI package versions as `1.0.0-ci.<n>` is moot now that CI uploads no package artifact. Recommend closing #20.