### PR TITLE
ci(release): enforce tag policy + internal alpha publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,20 @@ on:
       - 'v*'
 
 jobs:
+  validate-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce release tag naming policy
+        run: |
+          re='^v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|preview|rc)\.[0-9]+)?$'
+          if [[ ! "${GITHUB_REF_NAME}" =~ $re ]]; then
+            echo "::error::Tag '${GITHUB_REF_NAME}' is not an allowed release tag. Use vX.Y.Z or vX.Y.Z-{alpha|preview|rc}.N"
+            exit 1
+          fi
+          echo "Tag '${GITHUB_REF_NAME}' matches the release policy."
+
   release:
+    needs: validate-tag
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create the GitHub release
@@ -93,3 +106,39 @@ jobs:
 
       - name: Push to nuget.org
         run: dotnet nuget push 'packages/*.nupkg' --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --skip-duplicate
+
+  # Internal alpha builds -> UiPath Azure DevOps Artifacts feed (mirrors ServiceCommon).
+  # Only -alpha tags, gated by the PUBLISH_INTERNAL repo variable.
+  publish-internal:
+    needs: release
+    runs-on: ubuntu-latest
+    if: vars.PUBLISH_INTERNAL == 'true' && contains(github.ref_name, '-alpha')
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Derive version from tag
+        id: version
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Pack
+        run: dotnet pack UiPath.Caching.slnx -c Release -o packages /p:Version=${{ steps.version.outputs.value }}
+
+      - name: Add internal feed source
+        run: dotnet nuget add source "$FEED_URL" --name internal
+        env:
+          FEED_URL: ${{ secrets.AZDO_FEED_URL }}
+
+      - name: Push to internal feed
+        run: dotnet nuget push 'packages/*.nupkg' --source internal --api-key az --skip-duplicate
+        env:
+          NuGetPackageSourceCredentials_internal: Username=az;Password=${{ secrets.AZDO_ARTIFACTS_PAT }}


### PR DESCRIPTION
## Tag policy gate
New `validate-tag` job rejects any tag that isn't `vX.Y.Z` or `vX.Y.Z-{alpha|preview|rc}.N`. `release` needs it, and the publish jobs need `release` — so an off-convention tag (`v1.0.0-beta.1`, `v1.0`, `vfoo`) produces **no release and no package** (the run fails at validation).

## Internal alpha publishing
New `publish-internal` job:
- `-alpha` tags only, gated by the `PUBLISH_INTERNAL` repo variable (off until set).
- Pushes to the internal Azure DevOps Artifacts feed.
- Auth via NuGet env-var credentials — **no downloaded credential-provider script** (Sonar-clean), PAT in a masked env var (off disk).
- **Feed URL and PAT both come from secrets** (`AZDO_FEED_URL`, `AZDO_ARTIFACTS_PAT`), so neither the feed nor the token appears in the public workflow or logs.
- Re-packs at the tag (no stored artifact).

`-preview`/`-rc`/stable target nuget.org only.

### To activate later
Secrets: `AZDO_FEED_URL` (feed v3 index URL), `AZDO_ARTIFACTS_PAT` (Packaging: Read & write). Variable: `PUBLISH_INTERNAL=true`.