### PR TITLE
fix(release): build before pack in publish jobs (NU5026)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,8 +95,14 @@ jobs:
         id: version
         run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Restore
+        run: dotnet restore UiPath.Caching.slnx
+
+      - name: Build
+        run: dotnet build UiPath.Caching.slnx -c Release --no-restore /p:Version=${{ steps.version.outputs.value }}
+
       - name: Pack
-        run: dotnet pack UiPath.Caching.slnx -c Release -o packages /p:Version=${{ steps.version.outputs.value }}
+        run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}
 
       - name: Authenticate to nuget.org (OIDC trusted publishing)
         id: nuget-login
@@ -130,8 +136,14 @@ jobs:
         id: version
         run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Restore
+        run: dotnet restore UiPath.Caching.slnx
+
+      - name: Build
+        run: dotnet build UiPath.Caching.slnx -c Release --no-restore /p:Version=${{ steps.version.outputs.value }}
+
       - name: Pack
-        run: dotnet pack UiPath.Caching.slnx -c Release -o packages /p:Version=${{ steps.version.outputs.value }}
+        run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}
 
       - name: Add internal feed source
         run: dotnet nuget add source "$FEED_URL" --name internal


### PR DESCRIPTION
`v1.0.0-alpha.1` failed in `publish-internal` with `NU5026: ...UiPath.Caching.dll ... not found on disk`.

**Cause:** `publish-nuget` and `publish-internal` ran a bare `dotnet pack`. Because the projects set `GeneratePackageOnBuild=true`, pack expects the build output to already exist and doesn't produce it itself → `NU5026`. (`publish-nuget` had the same latent bug; it was just skipped.)

**Fix:** use the same sequence the `release` job already uses successfully — **Restore → Build → Pack `--no-build`** — in both publish jobs.

Verified locally: builds + packs the **6 src packages** (`UiPath.Caching[.Abstractions|.CloudEvents|.OpenTelemetry|.Polly|.Queue]`); sample/tests/benchmarks produce nothing (`IsPackable=false`). The auth/feed/secret setup was never the problem.