### PR TITLE
ci: add CodeQL (push/weekly) + FOSSA (push + release gate)

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -1,0 +1,9 @@
+version: 3
+
+# Scan only shipped code/dependencies. Tests, samples, and benchmarks are
+# dev-only (never redistributed), so their dependencies are excluded.
+paths:
+  exclude:
+    - tests
+    - samples
+    - benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     services:
       redis:
         image: redis:7
@@ -81,13 +80,6 @@ jobs:
       - name: Pack
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages
 
-      - name: FOSSA scan (license + CVE gate)
-        if: github.event_name == 'push' && env.FOSSA_API_KEY != ''
-        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
-        with:
-          api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true
-
   build-windows:
     runs-on: windows-latest
     steps:
@@ -111,3 +103,32 @@ jobs:
 
       # Redis-backed integration tests run on the Linux job (service containers are Linux-only).
       # Windows is build-only to validate cross-platform compilation.
+
+  # FOSSA runs as its own parallel job (push to main only) so it doesn't delay the build.
+  fossa:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore UiPath.Caching.slnx
+
+      - name: FOSSA scan (license + CVE gate)
+        if: env.FOSSA_API_KEY != ''
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     services:
       redis:
         image: redis:7
@@ -79,6 +80,13 @@ jobs:
 
       - name: Pack
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages
+
+      - name: FOSSA scan (license + CVE gate)
+        if: github.event_name == 'push' && env.FOSSA_API_KEY != ''
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,24 @@ on:
     - cron: '23 4 * * 1'  # weekly, Monday 04:23 UTC
 
 jobs:
+  # Code scanning is free on public repos but needs GitHub Advanced Security
+  # while private. Gate on visibility so runs are skipped (green) until the
+  # repo is public, then activate automatically — no workflow change needed.
+  check-visibility:
+    runs-on: ubuntu-latest
+    outputs:
+      public: ${{ steps.v.outputs.public }}
+    steps:
+      - id: v
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          vis=$(gh api "repos/${{ github.repository }}" --jq .visibility)
+          echo "public=$([ "$vis" = public ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
   analyze:
+    needs: check-visibility
+    if: needs.check-visibility.outputs.public == 'true'
     runs-on: ubuntu-latest
     permissions:
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 4 * * 1'  # weekly, Monday 04:23 UTC
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup .NET 8
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          languages: csharp
+          build-mode: manual
+
+      - name: Build
+        run: dotnet build UiPath.Caching.slnx -c Release
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          category: "/language:csharp"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create the GitHub release
+    env:
+      FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     services:
       redis:
         image: redis:7
@@ -58,6 +60,13 @@ jobs:
 
       - name: Test
         run: dotnet test UiPath.Caching.slnx -c Release --no-build
+
+      - name: FOSSA scan (license + CVE gate)
+        if: env.FOSSA_API_KEY != ''
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
 
       - name: Pack (validation only — not published or uploaded)
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}


### PR DESCRIPTION
Adds the two scans, with FOSSA configured to **fail the build** on CVE/license policy violations (per the requirement — a red check is the trigger, no need to watch the dashboard).

## CodeQL — `codeql.yml`
- C# analysis on **push to `main`** + **weekly** cron (Mon 04:23 UTC).
- Manual build (`dotnet build` the slnx between init/analyze) for reliable multi-target + central-package-management.
- Reports to the **Security** tab. No secret needed.
- ⚠️ Requires the repo to be **public** or **GitHub Advanced Security** enabled — otherwise CodeQL can't upload results and the run fails. Activates cleanly once public/GHAS-on.

## FOSSA
- **`ci.yml`** — `fossa analyze` + `fossa test` on **push to `main` only** (not PRs). `run-tests: true` → the job **fails** on any license or CVE policy violation.
- **`release.yml`** — same FOSSA gate in the `release` job (before Create Release), so a release **can't publish** with an open license/CVE issue; publish jobs `need` release.
- Both gated on the `FOSSA_API_KEY` secret, so they skip (green) until it's set.

### Requirement note
For `fossa test` to flag CVEs and license issues, the FOSSA project's **policy must enable vulnerability scanning + license rules**. The gate enforces whatever that policy flags.

### To activate
Add secret **`FOSSA_API_KEY`** (from app.fossa.com). CodeQL needs public/GHAS.