### PR TITLE
fix(fossa): analyze-only (push-only token)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,10 @@ jobs:
       - name: Restore
         run: dotnet restore UiPath.Caching.slnx
 
-      - name: FOSSA scan (license + CVE gate)
+      # Push-only token: upload only. CVE/license gating is enforced by the
+      # FOSSA GitHub App (which reads this analysis and posts a policy check).
+      - name: FOSSA analyze (upload)
         if: env.FOSSA_API_KEY != ''
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,12 +61,13 @@ jobs:
       - name: Test
         run: dotnet test UiPath.Caching.slnx -c Release --no-build
 
-      - name: FOSSA scan (license + CVE gate)
+      # Push-only token: upload only (records the released revision in FOSSA).
+      # CVE/license gating is enforced by the FOSSA GitHub App's policy check.
+      - name: FOSSA analyze (upload)
         if: env.FOSSA_API_KEY != ''
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
-          run-tests: true
 
       - name: Pack (validation only — not published or uploaded)
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}


### PR DESCRIPTION
The first FOSSA run failed: `fossa test` ran with no prior `fossa analyze`, and — more fundamentally — the token is **push-only**, which can `fossa analyze` (upload) but **cannot** `fossa test` (that reads results/policy).

**Fix:** both the CI `fossa` job and the release step now run **`fossa analyze` only** (upload), which works with the push-only token.

**Gating:** CVE/license enforcement (the requirement) moves to the **FOSSA GitHub App**, which reads the uploaded analysis and posts a blocking policy check. Push-only + App is FOSSA's recommended secure pattern for CI.

### To complete the gate
1. Install the **FOSSA GitHub App** on `UiPath/dotnet-caching` (org approval).
2. Configure the FOSSA project **policy** (license rules + vulnerability/CVE scanning) — that's what the App's check enforces.

Until the App is installed, `fossa analyze` just uploads to the FOSSA dashboard (no automated block).