### PR TITLE
ci(fossa): re-add fossa test gate (analyze + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,15 @@ jobs:
       - name: Restore
         run: dotnet restore UiPath.Caching.slnx
 
-      # Push-only token: upload only. CVE/license gating is enforced by the
-      # FOSSA GitHub App (which reads this analysis and posts a policy check).
       - name: FOSSA analyze (upload)
         if: env.FOSSA_API_KEY != ''
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: FOSSA test (license + CVE gate)
+        if: env.FOSSA_API_KEY != ''
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,13 +61,18 @@ jobs:
       - name: Test
         run: dotnet test UiPath.Caching.slnx -c Release --no-build
 
-      # Push-only token: upload only (records the released revision in FOSSA).
-      # CVE/license gating is enforced by the FOSSA GitHub App's policy check.
       - name: FOSSA analyze (upload)
         if: env.FOSSA_API_KEY != ''
         uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
         with:
           api-key: ${{ secrets.FOSSA_API_KEY }}
+
+      - name: FOSSA test (license + CVE gate)
+        if: env.FOSSA_API_KEY != ''
+        uses: fossas/fossa-action@ff70fe9fe17cbd2040648f1c45e8ec4e4884dcf3 # v1.9.0
+        with:
+          api-key: ${{ secrets.FOSSA_API_KEY }}
+          run-tests: true
 
       - name: Pack (validation only — not published or uploaded)
         run: dotnet pack UiPath.Caching.slnx -c Release --no-build -o packages /p:Version=${{ steps.version.outputs.value }}


### PR DESCRIPTION
Now that the FOSSA key supports reads, restore the two-step **analyze -> test** gate in both the CI fossa job and the release step. `fossa test` (run-tests) fails the build on CVE/license policy violations.

Note: requires the key's identity to have **create-project** permission in FOSSA (or the `github.com/UiPath/dotnet-caching` project pre-created), and the project **policy** (license + vulnerability) configured for the gate to flag.