### PR TITLE
feat(redis): port command filtering for the profiler (ServiceCommon#1858)

### DIFF
--- a/src/UiPath.Caching/Redis/ProfiledCommandExtensions.cs
+++ b/src/UiPath.Caching/Redis/ProfiledCommandExtensions.cs
@@ -87,7 +87,7 @@ public static class ProfiledCommandExtensions
     private static string GetCommand(this IProfiledCommand profiledCommand) =>
     !string.IsNullOrEmpty(profiledCommand.Command)
         ? profiledCommand.Command
-        : "UNKNOWN";
+        : ProfiledCommandProcessor.UnknownCommand;
 
     private static string? GetCommandAndKey(this IProfiledCommand profiledCommand)
     {

--- a/src/UiPath.Caching/Redis/ProfiledCommandProcessor.cs
+++ b/src/UiPath.Caching/Redis/ProfiledCommandProcessor.cs
@@ -1,10 +1,16 @@
+using Microsoft.Extensions.Options;
 using StackExchange.Redis.Profiling;
 using UiPath.Caching.Telemetry;
 
 namespace UiPath.Caching.Redis;
 
-public sealed class ProfiledCommandProcessor(ICachingTelemetryProvider telemetryProvider) : IProfiledCommandProcessor
+public sealed class ProfiledCommandProcessor(
+    ICachingTelemetryProvider telemetryProvider,
+    IOptions<RedisConnectionOptions> options) : IProfiledCommandProcessor
 {
+    private readonly HashSet<string> _commandDenyList =
+        new(options.Value.ProfilerCommandDenyList ?? [], StringComparer.OrdinalIgnoreCase);
+
     public static string FlagsField { get; set; } = "Flags";
 
     public static string CreationToEnqueuedField { get; set; } = "CreationToEnqueued";
@@ -23,6 +29,8 @@ public sealed class ProfiledCommandProcessor(ICachingTelemetryProvider telemetry
 
     public static string ProfileSessionIdField { get; set; } = "ProfileSessionId";
 
+    public static string UnknownCommand { get; set; } = "UNKNOWN";
+
     public static string UnknownTarget { get; set; } = "Unk";
 
     public static string UnknownRetransmissionReason { get; set; } = "N/A";
@@ -31,6 +39,13 @@ public sealed class ProfiledCommandProcessor(ICachingTelemetryProvider telemetry
 
     public void Process(IProfiledCommand command, string? sessionId)
     {
+        var baseCommand = string.IsNullOrEmpty(command.Command) ? UnknownCommand : command.Command;
+
+        if (_commandDenyList.Count > 0 && _commandDenyList.Contains(baseCommand))
+        {
+            return;
+        }
+
         var statement = command.GetStatement();
         var commandName = command.GetCommandName();
         var target = command.GetTarget();

--- a/src/UiPath.Caching/Redis/RedisConnectionOptions.cs
+++ b/src/UiPath.Caching/Redis/RedisConnectionOptions.cs
@@ -52,6 +52,8 @@ public class RedisConnectionOptions
 
     public bool ProfilerTrackMetricEnabled { get; set; } = true;
 
+    public IReadOnlyList<string> ProfilerCommandDenyList { get; set; } = [];
+
     public Func<ProfilingSession?>? ProfilingSessionFactory { get; set; }
 
     public ISystemClock? Clock { get; set; }

--- a/tests/UiPath.Caching.Tests/ProfiledCommandProcessorTests.cs
+++ b/tests/UiPath.Caching.Tests/ProfiledCommandProcessorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using StackExchange.Redis.Profiling;
 using UiPath.Caching.Telemetry;
 using UiPath.Caching.Tests.Telemetry;
@@ -14,6 +15,34 @@ public class ProfiledCommandProcessorTest : IAsyncLifetime
     private Lazy<RedisProfileFetcher> _oldFetcherLazy = default!;
 
     private ProfiledCommandProcessor Sut => _sut ??= _fixture.Create<ProfiledCommandProcessor>();
+
+    [Theory]
+    [InlineData("PING", "PING")]
+    [InlineData("PING", "ping")]
+    public void CommandProcessor_DeniedCommand_NotEmitted(string commandName, string denyListEntry)
+    {
+        _profiledCommand.Command.Returns(commandName);
+        _fixture.Inject<IOptions<RedisConnectionOptions>>(
+            Options.Create(new RedisConnectionOptions { ProfilerCommandDenyList = [denyListEntry] }));
+        _sut = null;
+
+        Sut.Process(_profiledCommand, _fixture.Create<string>());
+
+        _telemetryProvider.Dependencies.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CommandProcessor_AllowedCommand_Emitted()
+    {
+        _profiledCommand.Command.Returns("GET");
+        _fixture.Inject<IOptions<RedisConnectionOptions>>(
+            Options.Create(new RedisConnectionOptions { ProfilerCommandDenyList = ["PING"] }));
+        _sut = null;
+
+        Sut.Process(_profiledCommand, _fixture.Create<string>());
+
+        _telemetryProvider.Dependencies.Should().ContainSingle();
+    }
 
     [Fact]
     public void CommandProcessor_Null()
@@ -44,6 +73,7 @@ public class ProfiledCommandProcessorTest : IAsyncLifetime
     {
         _telemetryProvider = new RecordingTelemetryProvider();
         _fixture.Inject<ICachingTelemetryProvider>(_telemetryProvider);
+        _fixture.Inject<IOptions<RedisConnectionOptions>>(Options.Create(new RedisConnectionOptions()));
         _profiledCommand = _fixture.Freeze<IProfiledCommand>();
         _oldFetcherLazy = FetcherLazy;
         FetcherLazy = new(() => new RedisProfileFetcher


### PR DESCRIPTION
Ports **UiPath/ServiceCommon#1858** ("Add command filtering to profiler in Caching library") into the extracted repo.

- `RedisConnectionOptions.ProfilerCommandDenyList` + deny-list filtering in `ProfiledCommandProcessor`.
- Paths/namespaces remapped (`Caching/Caching.Runtime` → `src/UiPath.Caching`, `UiPath.Platform.Caching` → `UiPath.Caching`).
- Dropped the `Sample.AspNetCore/appsettings.all.json` change (no AspNetCore sample here).

Verified locally: solution builds clean, the 4 `ProfiledCommandProcessor` tests pass.

_(Ported via a local transform tool — not committed.)_