### PR TITLE
chore(deps): net10 Microsoft.Extensions.* 10.0.9 + dependabot ignore for MS.Extensions majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      # Microsoft.Extensions.* versions are framework-aligned via TFM-conditional
+      # ItemGroups in Directory.Packages.props (net8 -> 8.x, net10 -> 10.x).
+      # Block major bumps so Dependabot can't push 10.x onto the net8 target;
+      # cross-major moves are managed by hand.
+      - dependency-name: "Microsoft.Extensions.*"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,18 +25,18 @@
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.1" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.1" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## What
- Bump the **net10-conditional** `Microsoft.Extensions.*` entries in `Directory.Packages.props` from `10.0.1` → `10.0.9` (.NET 10 servicing). The `net8`-conditional group stays on `8.x`.
- Add a `dependabot.yml` ignore for `Microsoft.Extensions.*` **semver-major** updates.

## Why
Package versions are framework-aligned via two TFM-conditional `ItemGroups` (net8 → 8.x, net10 → 10.x) so net8 consumers aren't dragged onto .NET 10 assemblies. Dependabot can't see the conditional split under central package management, so it kept proposing 10.x bumps against the net8 entries (#33–#36, now closed). The ignore stops the recurring cross-major churn; net10 servicing patches like this one are done by hand.

Build + tests green on **net8.0 and net10.0** (1116/1116 each).