### PR TITLE
test: deflake caching timeout tests

### DIFF
--- a/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubTopicTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubTopicTests.cs
@@ -147,7 +147,8 @@ public class RedisPubSubTopicTests(ITestContextAccessor testContextAccessor) : I
     [Fact]
     public async Task Unsubscribe_is_called_when_subscriber_is_disposed()
     {
-        var sut = await Sut(5);
+        var sut = await Sut();
+        await WaitForSubscribeAsync();
         sut.Dispose();
         await _unsubscribeCalled.Task.WaitAsync(TimeSpan.FromSeconds(30), testContextAccessor.Current.CancellationToken);
         _subscriber.Received().Unsubscribe(Arg.Any<RedisChannel>(), Arg.Any<Action<RedisChannel, RedisValue>?>(), Arg.Any<CommandFlags>());

--- a/tests/UiPath.Caching.Tests/MultilayerCachePerNameFactoryTimeoutTests.cs
+++ b/tests/UiPath.Caching.Tests/MultilayerCachePerNameFactoryTimeoutTests.cs
@@ -68,15 +68,14 @@ public class MultilayerCachePerNameFactoryTimeoutTests(ITestContextAccessor test
     [Fact]
     public async Task GetOrAdd_FactoryTimeout_does_not_swallow_caller_cancellation()
     {
-        var policy = new CachePolicy { FactoryTimeout = TimeSpan.FromSeconds(10) };
+        var policy = new CachePolicy { FactoryTimeout = TimeSpan.FromSeconds(1) };
         using var cts = new CancellationTokenSource();
         Func<CancellationToken, Task<string?>> generator = async ct =>
         {
+            cts.Cancel();
             await Task.Delay(TimeSpan.FromSeconds(30), ct);
             return "v";
         };
-
-        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
         var act = async () => await Sut.GetOrAddAsync(_cacheKey, generator, policy, cts.Token);
 

--- a/tests/UiPath.Caching.Tests/MultilayerHashCachePerNameFactoryTimeoutTests.cs
+++ b/tests/UiPath.Caching.Tests/MultilayerHashCachePerNameFactoryTimeoutTests.cs
@@ -69,15 +69,14 @@ public class MultilayerHashCachePerNameFactoryTimeoutTests(ITestContextAccessor 
     [Fact]
     public async Task GetOrAdd_FactoryTimeout_does_not_swallow_caller_cancellation()
     {
-        var policy = new CachePolicy { FactoryTimeout = TimeSpan.FromSeconds(10) };
+        var policy = new CachePolicy { FactoryTimeout = TimeSpan.FromSeconds(1) };
         using var cts = new CancellationTokenSource();
         Func<CancellationToken, Task<IDictionary<string, string?>>> generator = async ct =>
         {
+            cts.Cancel();
             await Task.Delay(TimeSpan.FromSeconds(30), ct);
             return new Dictionary<string, string?> { ["f"] = "v" };
         };
-
-        cts.CancelAfter(TimeSpan.FromMilliseconds(50));
 
         var act = async () => await Sut.GetOrAddAsync(_cacheKey, generator, policy, cts.Token);
 

--- a/tests/UiPath.Caching.Tests/ResiliencePipelineFactoryTests.cs
+++ b/tests/UiPath.Caching.Tests/ResiliencePipelineFactoryTests.cs
@@ -121,7 +121,7 @@ public class ResiliencePipelineFactoryTest(ITestContextAccessor testContextAcces
             });
         var timeoutFunc = new Func<CancellationToken, ValueTask<bool>>(async token =>
         {
-            await Task.Delay(TimeSpan.FromSeconds(60), token);
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
             return true;
         });
         var exceptionFunc = new Func<CancellationToken, ValueTask<bool>>(token =>
@@ -134,7 +134,10 @@ public class ResiliencePipelineFactoryTest(ITestContextAccessor testContextAcces
         });
         var resiliencePipelineFactory = _fixture.Create<ResiliencePipelineFactory>();
         var pipeline = resiliencePipelineFactory.Create("read", false);
-        var act = async () => await pipeline.ExecuteAsync(timeoutFunc);
+        using var guard = CancellationTokenSource.CreateLinkedTokenSource(testContextAccessor.Current.CancellationToken);
+        guard.CancelAfter(TimeSpan.FromSeconds(5));
+
+        var act = async () => await pipeline.ExecuteAsync(timeoutFunc, guard.Token);
         await act.Should().ThrowAsync<TimeoutRejectedException>();
         bool? actual = null;
         for (int i = 0; i < 3; i++)


### PR DESCRIPTION
Makes the factory-timeout and resilience-timeout tests deterministic instead of racing wall-clock delays:

- **`Multilayer{Cache,HashCache}PerNameFactoryTimeoutTests`** — drop `FactoryTimeout` to 1s and cancel the token directly (`cts.Cancel()`) instead of `CancelAfter(50ms)`, so the timeout is hit deterministically rather than on a timer race.
- **`ResiliencePipelineFactoryTests`** — the slow func now waits indefinitely (`Timeout.InfiniteTimeSpan`) and the call is bounded by a 5s linked-token guard, so the pipeline's timeout policy is what fires (and the test can't hang).
- **`RedisPubSubTopicTests`** — the unsubscribe test awaits the subscribe signal (`WaitForSubscribeAsync()`) instead of a fixed `Sut(5)` delay.

Test-only; no production code changes. Affected classes pass 32/0.