### PR TITLE
chore(deps): bump OpenTelemetry family to 1.16.0 (supersedes #44)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -52,13 +52,13 @@
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="$(CloudEvents)" />
     <PackageVersion Include="Polly.Core" Version="8.6.5" />
     <PackageVersion Include="Polly.Extensions" Version="8.6.5" />
-    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.15.1-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.16.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />


### PR DESCRIPTION
## Why

Dependabot #44 bumped only `OpenTelemetry.Exporter.OpenTelemetryProtocol` to 1.16.0. That version requires `OpenTelemetry >= 1.16.0`, but the SDK was pinned at 1.15.3 → transitive **package downgrade (NU1605, error)** → CI Restore failed on both build-linux and build-windows. The OpenTelemetry packages have to move together.

## What

Aligns the OpenTelemetry packages to the 1.16.x line:

| Package | From | To |
|---|---|---|
| OpenTelemetry | 1.15.3 | 1.16.0 |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.15.3 | 1.16.0 |
| OpenTelemetry.Exporter.Console | 1.15.3 | 1.16.0 |
| OpenTelemetry.Extensions.Hosting | 1.15.3 | 1.16.0 |
| OpenTelemetry.Instrumentation.AspNetCore | 1.15.2 | 1.16.0 |
| OpenTelemetry.Instrumentation.Http | 1.15.1 | 1.16.0 |
| OpenTelemetry.Instrumentation.StackExchangeRedis | 1.15.1-beta.1 | 1.16.0-beta.1 |

`OpenTelemetry.Instrumentation.Runtime` stays at 1.15.1 (already the latest release).

## Verification

Full `dotnet build UiPath.Caching.slnx -c Release` clean on **net8.0** and **net10.0**; the NU1605 downgrade from #44 is gone.

Closes #44 (Dependabot will auto-close it once this merges and the target version is reached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)