### PR TITLE
feat(cla): authoritative CLA registry (replaces cla-signed label)

### DIFF
--- a/.claude/commands/cla-add-signer.md
+++ b/.claude/commands/cla-add-signer.md
@@ -1,0 +1,39 @@
+---
+description: Add a contributor to the CLA registry (signatures/cla.json) after legal has confirmed a signed CLA is on file. For CODEOWNERS/maintainers only.
+argument-hint: <github-username>
+---
+
+You are helping a **CODEOWNER/maintainer** record a contributor in the CLA registry
+(`signatures/cla.json`). Adding an entry is what turns a `cla-required` pull request's
+`legal/cla` check green, so treat this as a legal-record write: be precise and never
+invent data.
+
+Target signer (GitHub username), if provided: **$1**
+
+## Hard prerequisite — confirm before doing anything
+A registry entry means "UiPath legal has a valid signed CLA on file for this person/entity."
+Ask the maintainer to confirm they have **verified with legal that the signed CLA is recorded**
+(this is a manual, out-of-band step). If they cannot confirm, **stop** — do not add the entry.
+
+## Steps
+
+1. **Collect the entry fields.** Use `$1` as `githubUsername` if given; otherwise ask. Then gather the rest (ask via AskUserQuestion or prompt for any missing):
+   - `githubUsername` — the contributor's GitHub login (verify it exists, e.g. `gh api users/<name>`).
+   - `type` — `individual` or `corporate`.
+   - `entity` — the person's name, or the company name for a corporate CLA.
+   - `legalRef` — the UiPath legal record reference for the signed CLA (required; ask legal/the maintainer for it).
+   - `date` — date the signed CLA was recorded, today's date in `YYYY-MM-DD` unless told otherwise.
+   - `note` — optional free text.
+
+2. **Update the registry.** Read `signatures/cla.json`. If `githubUsername` (case-insensitive) is already present, stop and report it's already recorded. Otherwise append the new entry to `signatories`, keep the file valid JSON and 2-space indented, and leave existing entries untouched. Validate it parses (`python -m json.tool signatures/cla.json` or equivalent).
+
+3. **Open a PR — never commit to `main` directly.** The `signatures/` path is CODEOWNERS-gated so the addition gets a second pair of eyes and an audit trail:
+   - Create a branch: `chore/cla-signer-<githubUsername>`.
+   - Commit with sign-off (`git commit -s`); message e.g. `chore(cla): record signed CLA for <githubUsername> (<legalRef>)`.
+   - Push and open a PR to `main`. In the PR body, state the legal reference and that legal confirmation was obtained. Do **not** paste the CLA document or personal contact details beyond what the schema needs.
+
+4. **Tell the maintainer the follow-up.** After this PR merges, the contributor's own `cla-required` pull request must re-evaluate against the updated registry — it does not happen automatically. Instruct them to **toggle the `cla-required` label off and back on** on that PR (or have the contributor push a commit) so `cla.yml` re-runs and `legal/cla` turns green.
+
+## Notes
+- One entry per authorized GitHub username. For a corporate CLA covering several people, add one `type: corporate` entry per username, all referencing the same `entity`/`legalRef`.
+- See `signatures/README.md` for the schema and `CONTRIBUTING.md` for the full flow.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,7 @@
 # Caching library maintainers — default owners for everything in the repo.
 * @cosmin-staicu @litheon @cosminvlad @alinahornet @lucianaparaschivei @razvalex
+
+# CLA registry — entries are added only after a maintainer verifies with UiPath
+# legal that the signed CLA is on file. Approval routes to the maintainers here;
+# swap in a dedicated legal/CLA-approver team handle if one is created.
+/signatures/ @cosmin-staicu @litheon @cosminvlad @alinahornet @lucianaparaschivei @razvalex

--- a/.github/workflows/cla-triage.yml
+++ b/.github/workflows/cla-triage.yml
@@ -43,7 +43,7 @@ jobs:
             // If a maintainer already actioned this PR, don't add noise. cla-not-required is
             // a durable "reviewed, no CLA needed" state so a synchronize event can't re-flag it.
             const existing = pr.labels.map(l => l.name);
-            const actioned = ['cla-required', 'cla-signed', 'needs-cla-review', 'cla-not-required'];
+            const actioned = ['cla-required', 'needs-cla-review', 'cla-not-required'];
             if (existing.some(l => actioned.includes(l))) return;
 
             const files = await github.paginate(github.rest.pulls.listFiles, {

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,18 +1,16 @@
 name: CLA
 
 # Two-tier contribution model (see CONTRIBUTING.md):
-#   - DCO sign-off is required on every PR (see dco.yml).
+#   - DCO sign-off is enforced on every PR by the DCO GitHub App (org members exempt).
 #   - A signed Contributor License Agreement (CLA.md) is required ONLY for
-#     material/strategic contributions, escalated per-PR by a maintainer.
+#     material/strategic contributions, escalated per-PR by a maintainer applying
+#     the `cla-required` label.
 #
-# This workflow does NOT gate ordinary PRs. It publishes a `legal/cla` commit
-# status that is GREEN by default and only turns RED when a maintainer has
-# applied the `cla-required` label and the `cla-signed` label is not yet present.
-# Mark `legal/cla` as a required status check in branch protection to enforce it.
-#
-# Labels (create them once in the repo):
-#   - cla-required : maintainer flags a contribution as needing a signed CLA
-#   - cla-signed   : maintainer confirms UiPath has recorded the signed CLA
+# The authoritative "has a signed CLA on file" state is the CLA registry
+# (signatures/cla.json on the default branch), NOT a label. This job publishes a
+# `legal/cla` commit status that is GREEN by default and turns RED only when
+# `cla-required` is present AND the PR author is not yet in the registry.
+# Mark `legal/cla` as a required status check to enforce it.
 
 on:
   pull_request_target:
@@ -32,12 +30,28 @@ jobs:
         with:
           script: |
             const pr = context.payload.pull_request;
-            const labels = pr.labels.map(l => l.name);
-            const required = labels.includes('cla-required');
-            const signed = labels.includes('cla-signed');
-            const outstanding = required && !signed;
-
+            const required = pr.labels.map(l => l.name).includes('cla-required');
             const claUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CLA.md`;
+            const registryUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/signatures/cla.json`;
+
+            // Read the CLA registry from the BASE branch (trusted) — never the PR head,
+            // so a pull request cannot authorize its own author.
+            let signed = false;
+            try {
+              const res = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'signatures/cla.json',
+                ref: pr.base.ref,
+              });
+              const json = JSON.parse(Buffer.from(res.data.content, 'base64').toString('utf8'));
+              const users = (json.signatories || []).map(s => String(s.githubUsername || '').toLowerCase());
+              signed = users.includes(String(pr.user.login || '').toLowerCase());
+            } catch (e) {
+              if (e.status !== 404) throw e; // missing registry => treat as empty
+            }
+
+            const outstanding = required && !signed;
 
             await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
@@ -46,9 +60,9 @@ jobs:
               context: 'legal/cla',
               state: outstanding ? 'failure' : 'success',
               description: outstanding
-                ? 'Signed CLA required for this contribution — see CLA.md'
-                : (signed ? 'CLA recorded by UiPath' : 'No CLA required'),
-              target_url: claUrl,
+                ? 'Signed CLA required — author not yet in the CLA registry'
+                : (required ? 'CLA on file (author in registry)' : 'No CLA required'),
+              target_url: outstanding ? claUrl : registryUrl,
             });
 
             // Post the instructional comment once, when a CLA first becomes outstanding.
@@ -64,14 +78,14 @@ jobs:
 
             const body = [
               marker,
-              `Thanks for your contribution, @${pr.user.login}! A maintainer has flagged this as a **material or strategic** contribution, which requires a signed **Contributor License Agreement (CLA)** in addition to the DCO sign-off.`,
+              `Thanks for your contribution, @${pr.user.login}! A maintainer flagged this as a **material or strategic** contribution, which requires a signed **Contributor License Agreement (CLA)** in addition to the DCO sign-off.`,
               ``,
               `**What to do:**`,
               `1. Read the [CLA](${claUrl}).`,
               `2. Complete the section that applies to you — **Option A — Individual Contributor** or **Option B — Corporate Contributor** — and sign it.`,
               `3. Email the signed copy to **contractnotice@uipath.com**, referencing this pull request: ${pr.html_url}`,
               ``,
-              `Once UiPath records your signed CLA, a maintainer will add the \`cla-signed\` label and the \`legal/cla\` check will turn green. The CLA covers your present and future contributions, so this is a one-time step.`,
+              `Once UiPath records your signed CLA in the [CLA registry](${registryUrl}), the \`legal/cla\` check turns green. The CLA covers your present and future contributions, so this is a one-time step.`,
             ].join('\n');
 
             await github.rest.issues.createComment({

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ An automated check may add a `needs-cla-review` label to flag a pull request for
 
 1. A maintainer adds the `cla-required` label to your pull request, and an automated comment links to [CLA.md](./CLA.md). A `legal/cla` status check on the PR turns red while a CLA is outstanding.
 2. Read [CLA.md](./CLA.md), complete the section that applies to you (**Option A — Individual Contributor** or **Option B — Corporate Contributor**), sign it, and email the signed copy to **contractnotice@uipath.com**, referencing your pull request URL.
-3. Once UiPath has recorded your signed CLA, a maintainer adds the `cla-signed` label. The `legal/cla` check turns green and the pull request becomes eligible to merge.
+3. Once UiPath has confirmed and recorded your signed CLA, a maintainer adds you to the [CLA registry](./signatures/cla.json) (a reviewed, version-controlled record). The `legal/cla` check then turns green and the pull request becomes eligible to merge.
 
 The CLA covers your present and future Contributions, so you won't be asked to sign again for later pull requests — unless you change employers, in which case a new agreement is required (see clause 5.3 of the CLA).
 

--- a/signatures/README.md
+++ b/signatures/README.md
@@ -1,0 +1,47 @@
+# CLA registry
+
+`cla.json` is the **authoritative record** of contributors who have a signed
+[Contributor License Agreement](../CLA.md) on file with UiPath. The `legal/cla`
+status check ([`.github/workflows/cla.yml`](../.github/workflows/cla.yml)) reads
+this file from the default branch: when a maintainer marks a pull request
+`cla-required`, the check passes only once the PR author appears here.
+
+This is intentionally a committed, reviewed, version-controlled record rather than
+a label — every addition is an auditable change with who/what/when and a reference
+to the legal record.
+
+## Entry schema
+
+```jsonc
+{
+  "signatories": [
+    {
+      "githubUsername": "octocat",          // GitHub login (case-insensitive match)
+      "type": "individual",                  // "individual" or "corporate"
+      "entity": "Jane Doe",                  // person, or company name for corporate
+      "legalRef": "CLA-2026-0042",           // UiPath legal record reference
+      "date": "2026-06-30",                  // date the signed CLA was recorded (YYYY-MM-DD)
+      "note": "optional free-text"           // optional
+    }
+  ]
+}
+```
+
+For a **corporate** CLA, add one entry per authorized GitHub username covered by
+that company's agreement (set `type: "corporate"` and the company name in `entity`).
+
+## Adding a signatory
+
+Entries are added **only after a CODEOWNER has verified with UiPath legal that the
+signed CLA is on file.** Additions go through a pull request and are gated by
+[`CODEOWNERS`](../.github/CODEOWNERS) on this directory, so they require maintainer
+approval and leave an audit trail.
+
+Maintainers: use the `cla-add-signer` skill (in `.claude/skills/`) to do this, or
+edit `cla.json` by hand following the schema above. After the addition merges,
+re-trigger the contributor's `legal/cla` check (toggle the `cla-required` label off
+and on, or have them push) so it re-evaluates against the updated registry.
+
+The CLA covers a contributor's present and future contributions, so a signatory
+stays in this file permanently (unless they change employer — see clause 5.3 of the
+CLA, which requires a new agreement).

--- a/signatures/cla.json
+++ b/signatures/cla.json
@@ -1,0 +1,3 @@
+{
+  "signatories": []
+}


### PR DESCRIPTION
Makes the `legal/cla` gate derive from a **committed, reviewed registry** instead of the `cla-signed` label — so a green check means "UiPath holds a signed CLA for this author," not "a maintainer toggled a label."

## What

- **`signatures/cla.json`** — the CLA registry (authoritative record: `githubUsername`, `type`, `entity`, `legalRef`, `date`). `signatures/README.md` documents the schema/process.
- **`cla.yml`** — `legal/cla` now reads the registry **from the base branch** (never the PR head, so a PR can't self-authorize). RED only when `cla-required` is present **and** the PR author isn't in the registry; GREEN otherwise. The `cla-signed` label is no longer used.
- **`CODEOWNERS`** — `/signatures/` is gated by the maintainers; entries are added only after verifying with legal (swap in a dedicated legal team handle if one's created).
- **`/cla-add-signer`** (`.claude/commands/`) — maintainer command to record a signer: collects fields, validates, and opens a **PR** (CODEOWNERS-reviewed) rather than committing to `main`. Has a hard legal-verification prerequisite.
- **`cla-triage.yml`** — drop `cla-signed` from the "already actioned" set.
- **`CONTRIBUTING.md`** — documents the registry step.

## Labels
`cla-required`, `needs-cla-review`, `cla-not-required` stay. **`cla-signed` is retired** — delete the label after this merges.

## Flow
Material PR → maintainer applies `cla-required` → `legal/cla` RED → contributor signs + emails legal → maintainer verifies with legal and runs `/cla-add-signer` (PR into `signatures/cla.json`) → after it merges, re-toggle `cla-required` → `legal/cla` GREEN.

## Validated
`signatures/cla.json` parses; `cla.yml` is valid YAML and its script passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)