### PR TITLE
chore(deps): update Swashbuckle 10.2.3, Aspire.Hosting.Redis 13.4.6

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <CloudEvents>2.8.0</CloudEvents>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="MessagePack" Version="2.5.301" />
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
@@ -22,7 +22,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.28" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
@@ -37,12 +37,12 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
     
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.6" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
     <PackageVersion Include="Azure.Identity" Version="1.17.2" />

--- a/samples/UiPath.Caching.Sample.AppHost/AppHost.cs
+++ b/samples/UiPath.Caching.Sample.AppHost/AppHost.cs
@@ -36,13 +36,13 @@ if (useShardedRedis)
 }
 else
 {
-    var cache = builder.AddRedis("cache", port: 6379)
+    var cache = builder.AddRedis("cache")
         .WithDataVolume()
         .WithPersistence(TimeSpan.FromSeconds(20), keysChangedThreshold: 1);
 
     if (useRedisInsight)
     {
-        cache.WithRedisInsight(insight => insight.WithHostPort(8001));
+        cache.WithRedisInsight();
     }
 
     foreach (var sampleMachine in AddSampleMachines(builder, cache.Resource.ConnectionStringExpression, singleRedisExtraParams, shardKeyEnabled: false, useShardedPubSub: false, useOpenTelemetry: useOpenTelemetry, useSingleMachine: useSingleMachine))


### PR DESCRIPTION
Same updates as applied in ServiceCommon: unify Swashbuckle.AspNetCore on 10.2.3 for both TFMs, bump Aspire.Hosting.Redis to 13.4.6 (MessagePack 2.5.302 to satisfy its transitive floor), and drop the fixed sample Redis/RedisInsight host ports so Aspire assigns free ones (a fixed 6379 collides with any Redis already running on the dev machine, leaving the cache resource unhealthy). Build clean, 1166/1166 tests per TFM.