### PR TITLE
test: deflake keyed-lock serialization test entry guard

### DIFF
--- a/tests/UiPath.Caching.Tests/Locking/AsyncKeyedLocalLockTests.cs
+++ b/tests/UiPath.Caching.Tests/Locking/AsyncKeyedLocalLockTests.cs
@@ -69,7 +69,7 @@ public class AsyncKeyedLocalLockTests(ITestContextAccessor testContextAccessor)
 
         var tasks = Enumerable.Range(0, 32).Select(_ => Task.Run(Worker)).ToArray();
 
-        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(10), token);
+        await firstEntered.Task.WaitAsync(TimeSpan.FromSeconds(30), token);
         release.TrySetResult();
 
         await Task.WhenAll(tasks);


### PR DESCRIPTION
CI flake seen on #68 (net10.0): `Concurrent_callers_on_same_key_run_serially` timed out at the 10s `firstEntered` guard — 32 workers competing with the parallel suite on a 2-core runner can exceed it. Widen to 30s, matching the existing release guard. Guards remain hang protection, not perf assertions.