### PR TITLE
chore(deps): bump safe within-major NuGet updates

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,22 +21,22 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.28" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.29" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.3" />
   </ItemGroup>
   <ItemGroup>
@@ -59,14 +59,14 @@
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.7.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <!-- Public API surface tracking (src libraries only; wired in src/Directory.Build.props) -->
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <!-- Test related packages -->
     <PackageVersion Include="AwesomeAssertions" Version="9.4.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="xunit.v3" Version="$(xUnit)" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />

--- a/src/UiPath.Caching.Azure/UiPath.Caching.Azure.csproj
+++ b/src/UiPath.Caching.Azure/UiPath.Caching.Azure.csproj
@@ -8,7 +8,7 @@
     <PackageTags>UiPath;Caching;Azure;Entra;Redis</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />


### PR DESCRIPTION
## What

Manual dependency refresh for this weekly cycle. No Dependabot PRs were open (last batch merged Jul 7–9), so this does the equivalent by hand — **only the safe within-major / minor / patch bumps** that Dependabot's non-major PRs would raise.

### Bumps
| Package | From | To | Scope |
|---|---|---|---|
| `Microsoft.Extensions.*` | 10.0.9 | 10.0.10 | net10 group (12 packages) |
| `Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions` | 8.0.28 | 8.0.29 | net8 group |
| `Microsoft.Extensions.Http.Resilience` | 10.7.0 | 10.8.0 | global |
| `Microsoft.Extensions.ServiceDiscovery` | 10.7.0 | 10.8.0 | global |
| `OpenTelemetry.Instrumentation.Runtime` | 1.15.1 | 1.16.0 | global (aligns with other OTel 1.16.0 pkgs) |
| `Microsoft.NET.Test.Sdk` | 18.7.0 | 18.8.1 | test |

Also bumps the `Microsoft.Extensions.Options` `VersionOverride` in `UiPath.Caching.Azure` (10.0.9 → 10.0.10) so it stays aligned with the transitive net10 version — otherwise NuGet reports an `NU1605` downgrade error.

## Deliberately excluded (major bumps — each warrants its own review/testing)
- `StackExchange.Redis` 2.10.1 → 3.0.17 (core dependency)
- `NSubstitute` 5.3.0 → 6.0.0
- `coverlet.collector` 6.0.4 → 10.0.1
- `AsyncKeyedLock` 7.1.7 → 8.0.2

`Microsoft.Extensions.*` major bumps remain blocked by `dependabot.yml` (net8 TFM alignment).

## Verification
- `dotnet build -c Release` — succeeds (only pre-existing `CS0618 ManagedIdentityCredential` warnings, unrelated; fixed separately).
- `dotnet test -c Release` — **1169 passed, 4 skipped** (live-Redis integration), 0 failed, on both net8.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
