### PR TITLE
chore(deps): bump NSubstitute 6.0.0 and coverlet.collector 10.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,9 +73,9 @@
     <PackageVersion Include="AutoFixture" Version="$(AutoFixture)" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="$(AutoFixture)" />
-    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="NSubstitute" Version="6.0.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="AwesomeAssertions.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/tests/UiPath.Caching.Tests/MultilayerCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/MultilayerCacheTests.cs
@@ -166,7 +166,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
                 x[1] = new TestCacheEntry<string?> { Value = localValue };
                 return true;
             });
-        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k.Length == 1 && k.Contains(_innerMultiKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k != null && k.Length == 1 && k.Contains(_innerMultiKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(new KeyValuePair<CacheKey, ICacheEntry<string?>>[]
             {
                 new(_innerMultiKey, new TestCacheEntry<string?> { Value = remoteValue })
@@ -529,7 +529,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
 
         await _innerCache.DidNotReceive().RemoveAsync<string>(Arg.Any<CacheKey[]>(), Arg.Any<CancellationToken>());
         await _innerCache.Received(1).SetAsync<string?>(
-            Arg.Is<KeyValuePair<CacheKey, string?>[]>(p => p.Length == 2 && p.Any(kv => kv.Value == null)),
+            Arg.Is<KeyValuePair<CacheKey, string?>[]>(p => p != null && p.Length == 2 && p.Any(kv => kv.Value == null)),
             Arg.Any<DateTimeOffset?>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
     }
 
@@ -1001,7 +1001,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
     {
         var expected = _fixture.Create<bool>();
         var memoryCacheCalled = false;
-        _memoryCache.TryGetValue(Arg.Is<object>(o => (o.ToString() ?? string.Empty).Contains(_cacheKey)), out Arg.Any<object?>())
+        _memoryCache.TryGetValue(Arg.Is<object>(o => o != null && (o.ToString() ?? string.Empty).Contains(_cacheKey)), out Arg.Any<object?>())
             .Returns(x =>
             {
                 memoryCacheCalled = true;

--- a/tests/UiPath.Caching.Tests/MultilayerHashCacheRehydrateTests.cs
+++ b/tests/UiPath.Caching.Tests/MultilayerHashCacheRehydrateTests.cs
@@ -109,7 +109,7 @@ public class MultilayerHashCacheRehydrateTests(ITestContextAccessor testContextA
         await WaitForAsync(() => _innerCache.ReceivedCalls().Any(c => c.GetMethodInfo().Name == nameof(IHashCache.SetAsync)), TimeSpan.FromSeconds(5), token);
         await _innerCache.Received(1).SetAsync<string?>(
             _cacheKey,
-            Arg.Is<IDictionary<string, string?>>(d => d["f"] == "rehydrated"),
+            Arg.Is<IDictionary<string, string?>>(d => d != null && d["f"] == "rehydrated"),
             Arg.Is<HashCacheEntryOptions>(o => o.SetOption == HashCacheSetOption.KeyReplace),
             Arg.Any<CachePolicy?>(),
             Arg.Any<CancellationToken>());

--- a/tests/UiPath.Caching.Tests/MultilayerHashCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/MultilayerHashCacheTests.cs
@@ -359,7 +359,7 @@ public class MultilayerHashCacheTests(ITestContextAccessor testContextAccessor) 
 
         generatorWasCalled.Should().BeTrue();
         actual.Should().BeEmpty();
-        await _innerCache.Received().SetAsync(_innerCacheKey, Arg.Is<IDictionary<string, string?>>(d => d.Count == 0), Arg.Any<HashCacheEntryOptions>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        await _innerCache.Received().SetAsync(_innerCacheKey, Arg.Is<IDictionary<string, string?>>(d => d != null && d.Count == 0), Arg.Any<HashCacheEntryOptions>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public class MultilayerHashCacheTests(ITestContextAccessor testContextAccessor) 
         await Sut.SetAsync(_cacheKey, new Dictionary<string, string?>(), _fixture.Create<TimeSpan>(), token: testContextAccessor.Current.CancellationToken);
 
         await _innerCache.DidNotReceive().RemoveAsync<string>(_innerCacheKey, Arg.Any<CancellationToken>());
-        await _innerCache.Received(1).SetAsync(_innerCacheKey, Arg.Is<IDictionary<string, string?>>(d => d.Count == 0), Arg.Any<HashCacheEntryOptions>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        await _innerCache.Received(1).SetAsync(_innerCacheKey, Arg.Is<IDictionary<string, string?>>(d => d != null && d.Count == 0), Arg.Any<HashCacheEntryOptions>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -430,7 +430,7 @@ public class MultilayerHashCacheTests(ITestContextAccessor testContextAccessor) 
         await _innerCache.DidNotReceive().RemoveAsync<string>(_innerCacheKey, Arg.Any<CancellationToken>());
         await _innerCache.Received(1).SetAsync(
             _innerCacheKey,
-            Arg.Is<IDictionary<string, string?>>(d => d.Count == 0),
+            Arg.Is<IDictionary<string, string?>>(d => d != null && d.Count == 0),
             Arg.Is<HashCacheEntryOptions>(o => o.Metadata == metadata), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
     }
 


### PR DESCRIPTION
## What

The two test-infra **major** bumps deferred from #74 (the safe-bumps PR excluded majors for individual review):

- `NSubstitute` `5.3.0 → 6.0.0`
- `coverlet.collector` `6.0.4 → 10.0.1`

## Why it needed test changes

NSubstitute 6 annotated its public API for nullable reference types. As a result, the parameter of an `Arg.Is<T>(predicate)` matcher is now typed `T?`, so dereferencing it inside the predicate (`.Length`, `.Count`, indexer, `.ToString()`, `.Any(...)`) trips `CS8602` — and this repo builds with `TreatWarningsAsErrors`, so those became hard errors in the multilayer-cache tests.

Fix: guard each affected matcher predicate with a null check. The matchers compile to expression trees, which disallow the null-propagating operator (`?.` → `CS8072`), so `x != null && ...` is used rather than `x?.`. Seven predicates across three test files.

`coverlet.collector 10.0.1` needed no code changes.

## Verification
- `dotnet build -c Release` — succeeds, no errors/new warnings.
- `dotnet test -c Release` — **1169 passed, 4 skipped** (live-Redis integration), 0 failed, on both net8.0 and net10.0.

## Remaining deferred majors (not in this PR)
- `StackExchange.Redis` 2→3 (core dependency — separate, carefully-reviewed PR)
- `AsyncKeyedLock` 7→8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
