### PR TITLE
chore(deps): bump AsyncKeyedLock from 7.1.7 to 8.0.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,7 +47,7 @@
     <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
-    <PackageVersion Include="AsyncKeyedLock" Version="7.1.7" />
+    <PackageVersion Include="AsyncKeyedLock" Version="8.0.2" />
     <PackageVersion Include="CloudNative.CloudEvents" Version="$(CloudEvents)" />
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="$(CloudEvents)" />
     <PackageVersion Include="Polly.Core" Version="8.7.0" />


### PR DESCRIPTION
## What

`AsyncKeyedLock` `7.1.7 → 8.0.2` — the last of the deferred test/runtime major bumps.

## Impact

Version-only. `AsyncKeyedLocalLock` (the default `ILocalLock`) uses `AsyncKeyedLocker<string>`, `AsyncKeyedLockOptions(poolSize, poolInitialFill)`, `LockAsync(key, token)`, and `Dispose()` — all unchanged in 8.0, so no code changes were needed. The keyed-lock serialization test still passes.

## Verification
- `dotnet build -c Release` — succeeds, no errors/new warnings.
- `dotnet test -c Release` — **1169 passed, 4 skipped** (live-Redis integration), 0 failed, on both net8.0 and net10.0.

## Remaining deferred major (intentionally not here)
- `StackExchange.Redis` 2→3 — the core Redis client; deserves its own carefully-reviewed PR, not a routine bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
