### PR TITLE
docs: mark 1.0.1 released (CHANGELOG + promote unshipped public API)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-07-15
+
 ### Changed
 
 - Repository extracted from `UiPath/ServiceCommon` to the public `UiPath/dotnet-caching` repository under the MIT license. PackageIds are renamed `UiPath.Platform.Caching.*` → `UiPath.Caching.*` at the first nuget.org release.

--- a/src/UiPath.Caching.Queue/PublicAPI.Shipped.txt
+++ b/src/UiPath.Caching.Queue/PublicAPI.Shipped.txt
@@ -116,3 +116,9 @@ static UiPath.Caching.Config.SetCacheCollectionExtensions.AddRedisSetCache(this 
 static UiPath.Caching.Config.SetCacheCollectionExtensions.AddRedisSetCache(this UiPath.Caching.Config.ICachingBuilder! builder, System.Action<UiPath.Caching.Redis.RedisSetCacheOptions!>! configureOptions) -> UiPath.Caching.Config.ICachingBuilder!
 static UiPath.Caching.QueueCacheFactoryExtensions.CreateSetCache<T>(this UiPath.Caching.IQueueCacheFactory! factory) -> UiPath.Caching.ISetCache<T>!
 static readonly UiPath.Caching.NullSetCache.Instance -> UiPath.Caching.NullSetCache!
+UiPath.Caching.NullQueueCacheFactory
+UiPath.Caching.NullQueueCacheFactory.CreateSetCache() -> UiPath.Caching.ISetCache!
+UiPath.Caching.NullQueueCacheFactory.NullQueueCacheFactory() -> void
+static readonly UiPath.Caching.NullQueueCacheFactory.Instance -> UiPath.Caching.NullQueueCacheFactory!
+UiPath.Caching.Redis.RedisSetCacheOptions.Enabled.get -> bool
+UiPath.Caching.Redis.RedisSetCacheOptions.Enabled.set -> void

--- a/src/UiPath.Caching.Queue/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching.Queue/PublicAPI.Unshipped.txt
@@ -1,7 +1,1 @@
 #nullable enable
-UiPath.Caching.NullQueueCacheFactory
-UiPath.Caching.NullQueueCacheFactory.CreateSetCache() -> UiPath.Caching.ISetCache!
-UiPath.Caching.NullQueueCacheFactory.NullQueueCacheFactory() -> void
-static readonly UiPath.Caching.NullQueueCacheFactory.Instance -> UiPath.Caching.NullQueueCacheFactory!
-UiPath.Caching.Redis.RedisSetCacheOptions.Enabled.get -> bool
-UiPath.Caching.Redis.RedisSetCacheOptions.Enabled.set -> void

--- a/src/UiPath.Caching/PublicAPI.Shipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Shipped.txt
@@ -818,3 +818,4 @@ virtual UiPath.Caching.Redis.RedisCacheBase.Dispose(bool disposing) -> void
 ~UiPath.Caching.Config.NullConfigurationSection.this[string key].set -> void
 ~static readonly UiPath.Caching.Config.NullConfiguration.Instance -> Microsoft.Extensions.Configuration.IConfiguration
 ~static readonly UiPath.Caching.Config.NullConfigurationSection.Instance -> Microsoft.Extensions.Configuration.IConfigurationSection
+static UiPath.Caching.Config.ServiceCollectionExtensions.TryConfigure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<TOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!

--- a/src/UiPath.Caching/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Unshipped.txt
@@ -1,2 +1,1 @@
 #nullable enable
-static UiPath.Caching.Config.ServiceCollectionExtensions.TryConfigure<TOptions>(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, System.Action<TOptions!>! configureOptions) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!


### PR DESCRIPTION
## What

Marks **v1.0.1** as released (the `v1.0.1` tag is pushed and the Release workflow has run):

- **CHANGELOG:** the accumulated `## [Unreleased]` block becomes `## [1.0.1] - 2026-07-15`, with a fresh empty `## [Unreleased]` opened on top.
- **Public API baselines promoted** — entries that were in `PublicAPI.Unshipped.txt` are now shipped, so they move into `PublicAPI.Shipped.txt`:
  - `UiPath.Caching.Queue`: `NullQueueCacheFactory` (+ `Instance` / ctor / `CreateSetCache()`) and `RedisSetCacheOptions.Enabled` get/set.
  - `UiPath.Caching`: `ServiceCollectionExtensions.TryConfigure<TOptions>(...)`.
  - Both `PublicAPI.Unshipped.txt` files reset to just the `#nullable enable` header.

Appended to the shipped files (this repo keeps them unsorted).

## Note
Per the discussion when tagging: there was never a `[1.0.0]` CHANGELOG section, so this folds the previously-unreleased 1.0.0 content under `[1.0.1]`. Kept as-is per direction rather than retro-splitting a `[1.0.0]` section.

## Verification
- `dotnet build -c Release` — succeeds, no `RS0016`/`RS0017` public-API analyzer errors (every declared API is now accounted for in a shipped/unshipped file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
