### PR TITLE
test(redis): add live e2e guards for StackExchange.Redis internal reflection

### DIFF
--- a/tests/UiPath.Caching.Tests/Redis/ProfiledCommandExtensionsIntegrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/ProfiledCommandExtensionsIntegrationTests.cs
@@ -1,0 +1,38 @@
+using StackExchange.Redis;
+using StackExchange.Redis.Profiling;
+using UiPath.Caching.Redis;
+
+namespace UiPath.Caching.Tests.Redis;
+
+[Collection("RedisIntegration")]
+[Trait("Category", "Integration")]
+public class ProfiledCommandExtensionsIntegrationTests(RedisContainerFixture fixture)
+{
+    [Fact]
+    public async Task GetStatement_IncludesKey_FromLiveProfiledCommand()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+
+        await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(fixture.ConnectionString);
+        var database = multiplexer.GetDatabase();
+        await database.PingAsync();
+
+        var session = new ProfilingSession();
+        multiplexer.RegisterProfiler(() => session);
+
+        var key = $"profiled-{Guid.NewGuid():N}";
+        await database.StringSetAsync(key, "value");
+        await database.StringGetAsync(key);
+
+        var commands = session.FinishProfiling().ToList();
+
+        var keyed = commands.FirstOrDefault(c =>
+            (string.Equals(c.Command, "SET", StringComparison.Ordinal) || string.Equals(c.Command, "GET", StringComparison.Ordinal))
+            && c.GetStatement().Contains(key, StringComparison.Ordinal));
+
+        keyed.Should().NotBeNull();
+        keyed!.GetStatement().Should().NotBe(keyed.GetCommandName());
+        keyed.GetStatement().Should().StartWith(keyed.Command).And.Contain(key);
+        keyed.GetTarget().Should().NotBeNullOrEmpty().And.Contain(":");
+    }
+}

--- a/tests/UiPath.Caching.Tests/Redis/RedisConnectorIntegrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConnectorIntegrationTests.cs
@@ -65,5 +65,7 @@ public class RedisConnectorIntegrationTests(RedisContainerFixture fixture)
         var metrics = connector.GetMasterPhysicalConnectionMetrics(multiplexer);
 
         metrics.Should().NotBeNull();
+        metrics!.EndPoint.Should().BeOneOf(multiplexer.GetEndPoints());
+        metrics.AwaitingResponseCount.Should().BeGreaterThanOrEqualTo(0);
     }
 }


### PR DESCRIPTION
## Summary

Adds live end-to-end tests that guard the two places where the library reflects into StackExchange.Redis **private internals**. Both fail silently, so unit tests (which mock the Redis interfaces) can't detect them degrading — this lands the guards *before* the upcoming StackExchange.Redis `2.1x` and `3.0` upgrades so those bumps have a real runtime tripwire.

## Changes

- **New `ProfiledCommandExtensionsIntegrationTests`** — runs a keyed command against live Redis and asserts `GetStatement()` carries the key. That only holds when the `ProfiledCommand.Message` → `Message.CommandAndKey` reflection resolves; on a silent miss it falls back to the bare command name and the test fails.
- **Strengthened `GetMasterPhysicalConnectionMetrics` test** — was a bare `NotBeNull`; now also asserts the reflected endpoint and a sane `AwaitingResponseCount`, so a wrong-but-present field bind returning garbage is caught, not just a null.

Both are gated behind `RUN_REDIS_INTEGRATION_TESTS=1` (no change to the default test run).

Context: `3.0` is an internal IO-core rewrite touching exactly the `PhysicalConnection`/`PhysicalBridge` internals the hang-detection reflection reads. All 7 reflected members still exist at tag `3.0.17`, but only a live test proves the runtime values still resolve.

## Test plan

- [x] Unit tests added/updated
- [x] Integration tests pass locally (`dotnet test`)
- [ ] CHANGELOG.md updated <!-- test-only, no library behavior change -->

Verified against a live Redis on **net8.0** and **net10.0** at the current `2.10.1` baseline (all 9 integration tests pass). Also mutation-proved the profiling guard: forcing the reflection to miss drops the key from `GetStatement()` and the test fails as intended.

## Linked issues

Fixes #

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)