### PR TITLE
chore(deps): bump StackExchange.Redis from 2.10.1 to 2.13.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped `StackExchange.Redis` from 2.10.1 to 2.13.17 (latest 2.x), the first step of the staged upgrade toward 3.0. No public API or runtime behavior change.
+
 ## [1.0.1] - 2026-07-15
 
 ### Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.6" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.10.1" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.13.17" />
     <PackageVersion Include="Azure.Identity" Version="1.21.0" />
     <PackageVersion Include="Microsoft.Azure.StackExchangeRedis" Version="3.3.1" />
     <PackageVersion Include="AsyncKeyedLock" Version="8.0.2" />

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamTopicMonitorTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamTopicMonitorTests.cs
@@ -306,19 +306,27 @@ public class RedisStreamHealthMaintainerTests(ITestContextAccessor testContextAc
 
     private StreamInfo GenerateStreamInfo(int? groupsCount = null)
     {
-        //int length, int radixTreeKeys, int radixTreeNodes, int groups, StreamEntry firstEntry, StreamEntry lastEntry, RedisValue lastGeneratedId
-        object?[] args = [
-               (object?)_fixture.Create<int>(),
-                       (object?)_fixture.Create<int>(),
-                       (object?)_fixture.Create<int>(),
-                       (object?) groupsCount ?? _fixture.Create<int>(),
-                       (object?)_fixture.Create<StreamEntry>(),
-                       (object?)_fixture.Create<StreamEntry>(),
-                       (object?)(RedisValue)_lastGeneratedId
-            ];
+        // StreamInfo's internal ctor keeps its leading params (length, radixTreeKeys, radixTreeNodes,
+        // groups, firstEntry, lastEntry, lastGeneratedId) stable but grows a trailing tail across
+        // StackExchange.Redis versions. Fill by the actual ctor's parameter list and set only the
+        // fields the maintainer reads, so version bumps that append params don't break this fixture.
+        var ctor = typeof(StreamInfo).GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic).Single();
+        var parameters = ctor.GetParameters();
+        var args = new object?[parameters.Length];
+        for (var i = 0; i < parameters.Length; i++)
+        {
+            args[i] = parameters[i].ParameterType.IsValueType ? Activator.CreateInstance(parameters[i].ParameterType) : null;
+        }
 
-        var streamInfo = (StreamInfo)Activator.CreateInstance(typeof(StreamInfo), BindingFlags.Instance | BindingFlags.NonPublic, null, args, null)!;
-        return streamInfo;
+        args[0] = _fixture.Create<int>();
+        args[1] = _fixture.Create<int>();
+        args[2] = _fixture.Create<int>();
+        args[3] = groupsCount ?? _fixture.Create<int>();
+        args[4] = _fixture.Create<StreamEntry>();
+        args[5] = _fixture.Create<StreamEntry>();
+        args[6] = (RedisValue)_lastGeneratedId;
+
+        return (StreamInfo)ctor.Invoke(args);
     }
 
     private StreamGroupInfo GenerateGroupInfo(DateTimeOffset lastGenerated, int? consumerCount = null)


### PR DESCRIPTION
## Summary

First step of the staged StackExchange.Redis upgrade toward `3.0`. `2.13.17` is the latest `2.x` and shares `3.0`'s public API (3.0.0 is a mirror of 2.13.17 with a rewritten internal IO core), so landing it first de-risks the major bump. No public API or runtime behavior change.

## Changes

- Bump `StackExchange.Redis` `2.10.1` → `2.13.17` in `Directory.Packages.props`.
- Fix `RedisStreamHealthMaintainerTests` fixture: SE.Redis 2.13.17 grew the **internal** `StreamInfo` constructor from **7 → 16 parameters**. The test fabricates `StreamInfo` via reflection with a hardcoded positional arg list, so the old 7-arg call no longer bound — the fixture threw, the maintainer's `try/catch` swallowed it, and it surfaced as `received no matching calls` on the downstream `IDatabase` mocks. **Production is unaffected** (it gets real `StreamInfo` objects from SE.Redis deserialization, never this reflection). `GenerateStreamInfo` now fills by the ctor's actual parameter list and sets only the fields the maintainer reads, so it survives this bump *and* the upcoming 3.0 one.
- CHANGELOG entry under `[Unreleased]`.

## Test plan

- [x] Unit tests added/updated <!-- fixture hardened -->
- [x] Integration tests pass locally (`dotnet test`)
- [x] CHANGELOG.md updated

Full suite green on **net8.0** and **net10.0** — **1174/1174 each** — run with `RUN_REDIS_INTEGRATION_TESTS=1` against a live Redis, including the reflection guards added in #82 (`GetMasterPhysicalConnectionMetrics` and the profiling `GetStatement`). Confirmed via a controlled revert that the fixture failure was caused by the bump and is fully resolved by the fixture fix.

## Linked issues

Fixes #

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)