### PR TITLE
feat(redis): add AddRedisConfigurationOptionsProvider factory overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- `RedisCollectionExtensions.AddRedisConfigurationOptionsProvider(this ICachingBuilder, Func<IServiceProvider, IRedisConfigurationOptionsProvider>)` — registers a custom `IRedisConfigurationOptionsProvider` via a factory delegate, replacing the default `RedisConfigurationOptionsProvider`. Order-independent (uses `Replace`), so it can be called before or after `AddRedisConnection` and the supplied factory always wins. Previously a custom provider required manually pre-registering it so the `TryAdd` default backed off.
+
 ### Changed
 
 - Bumped `StackExchange.Redis` from 2.10.1 to 2.13.17 (latest 2.x), the first step of the staged upgrade toward 3.0. No public API or runtime behavior change.

--- a/src/UiPath.Caching/Config/RedisCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/RedisCollectionExtensions.cs
@@ -50,6 +50,20 @@ public static class RedisCollectionExtensions
         return builder.AddRedisConnection(redisConnectionOptions);
     }
 
+    /// <summary>
+    /// Registers a custom <see cref="IRedisConfigurationOptionsProvider"/> built by <paramref name="factory"/>,
+    /// replacing the default <see cref="RedisConfigurationOptionsProvider"/>. Can be called before or after
+    /// <c>AddRedisConnection</c> — the supplied factory always wins.
+    /// </summary>
+    public static ICachingBuilder AddRedisConfigurationOptionsProvider(
+        this ICachingBuilder builder,
+        Func<IServiceProvider, IRedisConfigurationOptionsProvider> factory)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        builder.Services.Replace(ServiceDescriptor.Transient(factory));
+        return builder;
+    }
+
     private static ICachingBuilder AddRedisConnection(this ICachingBuilder builder, RedisConnectionOptions redisConnectionOptions)
     {
         builder

--- a/src/UiPath.Caching/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static UiPath.Caching.Config.RedisCollectionExtensions.AddRedisConfigurationOptionsProvider(this UiPath.Caching.Config.ICachingBuilder! builder, System.Func<System.IServiceProvider!, UiPath.Caching.Redis.IRedisConfigurationOptionsProvider!>! factory) -> UiPath.Caching.Config.ICachingBuilder!

--- a/tests/UiPath.Caching.Tests/Redis/RedisConfigurationOptionsProviderFactoryTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConfigurationOptionsProviderFactoryTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using UiPath.Caching.Config;
+using UiPath.Caching.Redis;
+
+namespace UiPath.Caching.Tests.Redis;
+
+public class RedisConfigurationOptionsProviderFactoryTests
+{
+    private sealed class FakeConfigurationOptionsProvider : IRedisConfigurationOptionsProvider
+    {
+        public ConfigurationOptions GetConfiguration() => new();
+    }
+
+    [Fact]
+    public void Factory_provider_wins_when_registered_after_AddRedisConnection()
+    {
+        var custom = new FakeConfigurationOptionsProvider();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCaching(builder => builder
+            .AddRedisConnection(opt => opt.ConnectionString = "localhost:6379")
+            .AddRedisConfigurationOptionsProvider(_ => custom));
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IRedisConfigurationOptionsProvider>().Should().BeSameAs(custom);
+    }
+
+    [Fact]
+    public void Factory_provider_wins_when_registered_before_AddRedisConnection()
+    {
+        var custom = new FakeConfigurationOptionsProvider();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCaching(builder => builder
+            .AddRedisConfigurationOptionsProvider(_ => custom)
+            .AddRedisConnection(opt => opt.ConnectionString = "localhost:6379"));
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IRedisConfigurationOptionsProvider>().Should().BeSameAs(custom);
+    }
+
+    [Fact]
+    public void Default_provider_used_when_no_factory_registered()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCaching(builder => builder.AddRedisConnection(opt => opt.ConnectionString = "localhost:6379"));
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IRedisConfigurationOptionsProvider>().Should().BeOfType<RedisConfigurationOptionsProvider>();
+    }
+
+    [Fact]
+    public void Null_factory_throws()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddCaching(builder => builder.AddRedisConfigurationOptionsProvider(null!));
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a first-class way to inject a custom `IRedisConfigurationOptionsProvider` via a factory delegate, instead of the current workaround (manually pre-registering your provider so the default `TryAdd` registration backs off).

```csharp
builder.AddRedisConfigurationOptionsProvider(sp => new MyConfigProvider(
    sp.GetRequiredService<ILoggerFactory>(),
    sp.GetRequiredService<IOptions<RedisConnectionOptions>>()));
```

## Changes

- New `RedisCollectionExtensions.AddRedisConfigurationOptionsProvider(this ICachingBuilder, Func<IServiceProvider, IRedisConfigurationOptionsProvider>)`. It uses `Services.Replace`, so it is **order-independent** relative to `AddRedisConnection` — the supplied factory always wins whether called before or after (the default is registered with `TryAddTransient`). Null factory throws `ArgumentNullException`.
- `PublicAPI.Unshipped.txt` updated for the new public method.
- CHANGELOG entry under `[Unreleased] / Added`.

## Notes

This is the config-options **provider** (builds the `ConfigurationOptions` from `RedisConnectionOptions`). It's independent of the connection-multiplexer factory hooks (`RedisConnectionOptions.ConnectionMultiplexerFactoryType` / `ConnectionFactory`) and of `IRedisConnectionConfigurator` (the per-connect `ConfigurationOptions` mutation hook for auth). This just makes replacing the provider a documented one-liner rather than a DI-ordering trick.

## Test plan

- [x] Unit tests added/updated
- [x] Integration tests pass locally (`dotnet test`)
- [x] CHANGELOG.md updated

New `RedisConfigurationOptionsProviderFactoryTests` covers: factory wins when registered **after** `AddRedisConnection`, factory wins when registered **before**, default provider used when no factory registered, and null-factory throws. Full suite green on **net8.0** and **net10.0** (1178/1178 each).

## Linked issues

Fixes #

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)