### PR TITLE
perf(redis): keep JSON serialization on UTF-8 bytes instead of UTF-16 strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Bumped `StackExchange.Redis` from 2.13.17 to 3.0.17. 3.0 is an internal IO-core rewrite that mirrors 2.13.17's public API, so there is no public API change here. The live hang-detection and profiling reflection paths were verified against a real Redis on both target frameworks.
 - **Obsolete:** `RedisConnectionOptions.ThreadPoolSocketManager` no longer has any effect and is marked `[Obsolete]`. StackExchange.Redis 3.0 removed `SocketManager` (its IO core no longer uses one), so the setting is now a no-op; it will be removed in a future major release.
 
+### Performance
+
+- Serialization now stays on UTF-8 bytes end-to-end instead of round-tripping through UTF-16 `string`s. JSON is UTF-8 on the wire, so the string hop was a pure allocation + transcode on every read/write. Measured with BenchmarkDotNet (`SerializerBenchmark`), this roughly **halves allocations** on the serialize/deserialize paths (e.g. large-payload deserialize `1,385,629 B → 607,714 B`, serialize `778,689 B → 389,660 B`) with equal-or-better throughput. No public API changes.
+  - `SystemJsonSerializerProxy` (the default proxy shared by `RedisCache`, `RedisHashCache`, `RedisSetCache`, `RedisCacheProvider`) serializes via `JsonSerializer.SerializeToUtf8Bytes` and deserializes from the `RedisValue` payload as `ReadOnlySpan<byte>`. The benchmark also measured a `ReadOnlySequence<byte>`/`Utf8JsonReader` variant; it allocated identically to the span path but was slower for these (single-segment) payloads, so the span path was chosen.
+  - `CacheEventFormatter.Encode` uses `SerializeToUtf8Bytes` (dropping the intermediate string + `Encoding.UTF8.GetBytes`); the Redis broadcast publish paths (`RedisPubSubTopic`, `RedisStreamsTopic`) publish the encoded bytes as a `RedisValue` directly instead of via `EncodeAsString`; and the subscribe paths (`RedisPubSubSubjectWriter`, `RedisStreamSubjectWriter`) decode from the `RedisValue` bytes instead of `value.ToString()`.
+  - Wire format is unchanged everywhere — values written by the previous string paths still deserialize.
+
+### Deprecated
+
+- `IEventFormatterProxy<T>.Decode(string)` and `IEventFormatterProxy<T>.EncodeAsString(T)` are marked `[Obsolete]`. They forced a UTF-16 transcode and are no longer used by the library; use the byte-based `Decode(ReadOnlyMemory<byte>)` / `Encode(T)` instead.
+
 ## [1.0.1] - 2026-07-15
 
 ### Changed

--- a/benchmarks/UiPath.Caching.Benchmarks/SerializerBenchmark.cs
+++ b/benchmarks/UiPath.Caching.Benchmarks/SerializerBenchmark.cs
@@ -1,0 +1,51 @@
+using System.Buffers;
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using StackExchange.Redis;
+
+namespace UiPath.Caching.Benchmarks;
+
+[MemoryDiagnoser]
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[CategoriesColumn]
+public class SerializerBenchmark
+{
+    [Params("Small", "Medium", "Large")]
+    public string Size { get; set; } = "Medium";
+
+    private CustomObject _obj = default!;
+    private RedisValue _payload;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _obj = Size switch
+        {
+            "Small" => CustomObject.RandomSmall(),
+            "Large" => CustomObject.RandomLarge(),
+            _ => CustomObject.RandomMedium(),
+        };
+        _payload = JsonSerializer.SerializeToUtf8Bytes(_obj);
+    }
+
+    [BenchmarkCategory("Serialize"), Benchmark(Baseline = true)]
+    public RedisValue Serialize_String() => JsonSerializer.Serialize(_obj);
+
+    [BenchmarkCategory("Serialize"), Benchmark]
+    public RedisValue Serialize_Utf8Bytes() => JsonSerializer.SerializeToUtf8Bytes(_obj);
+
+    [BenchmarkCategory("Deserialize"), Benchmark(Baseline = true)]
+    public CustomObject? Deserialize_String() => JsonSerializer.Deserialize<CustomObject>((string)_payload!);
+
+    [BenchmarkCategory("Deserialize"), Benchmark]
+    public CustomObject? Deserialize_Span() => JsonSerializer.Deserialize<CustomObject>(((ReadOnlyMemory<byte>)_payload).Span);
+
+    [BenchmarkCategory("Deserialize"), Benchmark]
+    public CustomObject? Deserialize_Sequence()
+    {
+        ReadOnlySequence<byte> payload = _payload;
+        var reader = new Utf8JsonReader(payload);
+        return JsonSerializer.Deserialize<CustomObject>(ref reader);
+    }
+}

--- a/src/UiPath.Caching.Abstractions/Broadcast/IEventFormatterProxy.cs
+++ b/src/UiPath.Caching.Abstractions/Broadcast/IEventFormatterProxy.cs
@@ -3,6 +3,7 @@ namespace UiPath.Caching.Broadcast;
 public interface IEventFormatterProxy<T>
      where T : IEvent
 {
+    [Obsolete("Use Decode(ReadOnlyMemory<byte>); decoding from the RedisValue payload bytes avoids a UTF-16 transcode.")]
     T? Decode(string body) =>
         Decode(new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes(body)));
 
@@ -10,6 +11,7 @@ public interface IEventFormatterProxy<T>
 
     ReadOnlyMemory<byte> Encode(T @event);
 
+    [Obsolete("Use Encode(T); publishing the encoded bytes directly avoids a UTF-16 transcode.")]
     string? EncodeAsString(T @event) =>
         Encoding.UTF8.GetString(Encode(@event).Span);
 }

--- a/src/UiPath.Caching/Broadcast/CacheEventFormatter.cs
+++ b/src/UiPath.Caching/Broadcast/CacheEventFormatter.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using System.Text.Json;
 
 namespace UiPath.Caching.Broadcast;
@@ -8,9 +7,6 @@ public sealed class CacheEventFormatter : IEventFormatterProxy<ICacheEvent>
     public ICacheEvent? Decode(ReadOnlyMemory<byte> body) =>
         JsonSerializer.Deserialize<CacheEvent>(body.Span);
 
-    public ReadOnlyMemory<byte> Encode(ICacheEvent clearCacheEvent)
-    {
-        var str = JsonSerializer.Serialize((CacheEvent)clearCacheEvent);
-        return Encoding.UTF8.GetBytes(str);
-    }
+    public ReadOnlyMemory<byte> Encode(ICacheEvent clearCacheEvent) =>
+        JsonSerializer.SerializeToUtf8Bytes((CacheEvent)clearCacheEvent);
 }

--- a/src/UiPath.Caching/Broadcast/Redis/RedisPubSubSubjectWriter.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisPubSubSubjectWriter.cs
@@ -95,7 +95,7 @@ internal sealed partial class RedisPubSubSubjectWriter<T> : IDisposable
         {
             try
             {
-                var ev = _formatter.Decode(value.ToString());
+                var ev = _formatter.Decode((ReadOnlyMemory<byte>)value);
                 if (ev is null)
                 {
                     return;

--- a/src/UiPath.Caching/Broadcast/Redis/RedisPubSubTopic.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisPubSubTopic.cs
@@ -66,12 +66,12 @@ public sealed partial class RedisPubSubTopic<T> : ITopic<T>
 
         try
         {
-            var messageString = _formatter.EncodeAsString(@event);
+            RedisValue message = _formatter.Encode(@event);
             LogPublishing(TopicKey, @event.Id);
             var response = await _write.ExecuteAsync(async token =>
             {
                 token.ThrowIfCancellationRequested();
-                return await _redis.Database.PublishAsync(_redisChannel, messageString, CommandFlags.DemandMaster).ConfigureAwait(false);
+                return await _redis.Database.PublishAsync(_redisChannel, message, CommandFlags.DemandMaster).ConfigureAwait(false);
             }, defaultValue: -1, token).ConfigureAwait(false);
             return response >= 0;
         }

--- a/src/UiPath.Caching/Broadcast/Redis/RedisStreamSubjectWriter.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisStreamSubjectWriter.cs
@@ -196,7 +196,7 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
 
         try
         {
-            var ev = _formatter.Decode(@event[_context.FieldName].ToString());
+            var ev = _formatter.Decode((ReadOnlyMemory<byte>)@event[_context.FieldName]);
             if (ev is null)
             {
                 return default;

--- a/src/UiPath.Caching/Broadcast/Redis/RedisStreamsTopic.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisStreamsTopic.cs
@@ -105,14 +105,14 @@ public sealed partial class RedisStreamsTopic<T> : ITopic<T>
 
         try
         {
-            RedisValue messageString = _formatter.EncodeAsString(@event);
+            RedisValue message = _formatter.Encode(@event);
             var id = await _write.ExecuteAsync(async token =>
             {
                 token.ThrowIfCancellationRequested();
                 return await _redis.Database.StreamAddAsync(
                     _context.Topic,
                     _context.FieldName,
-                    messageString,
+                    message,
                     maxLength: _streamOptions.MaxLength,
                     useApproximateMaxLength: true,
                     flags: CommandFlags.DemandMaster).ConfigureAwait(false);

--- a/src/UiPath.Caching/SystemJsonSerializerProxy.cs
+++ b/src/UiPath.Caching/SystemJsonSerializerProxy.cs
@@ -10,10 +10,18 @@ public class SystemJsonSerializerProxy : ISerializerProxy<RedisValue>
         _options = options;
 
     public RedisValue Serialize(object? value) =>
-        JsonSerializer.Serialize(value, _options);
+        JsonSerializer.SerializeToUtf8Bytes(value, _options);
 
-    public T? Deserialize<T>(RedisValue value) =>
-        value.IsNullOrEmpty ? default : JsonSerializer.Deserialize<T>(value!, _options);
+    public T? Deserialize<T>(RedisValue value)
+    {
+        if (value.IsNullOrEmpty)
+        {
+            return default;
+        }
+
+        ReadOnlyMemory<byte> payload = value;
+        return JsonSerializer.Deserialize<T>(payload.Span, _options);
+    }
 
     public bool TryDeserialize<T>(string? value, out T? result)
     {
@@ -45,7 +53,7 @@ public class SystemJsonSerializerProxy : ISerializerProxy<RedisValue>
         {
             if(value is JsonElement jsonElement)
             {
-                result = JsonSerializer.Deserialize<T>(jsonElement.GetRawText(), _options);
+                result = jsonElement.Deserialize<T>(_options);
                 return true;
             }
             else

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
@@ -39,7 +39,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         Func<Task> act = async () => await Sut.FetchTask;
         await act.Should().NotCompleteWithinAsync(500.Microseconds());
         _cancellationTokenSource.Cancel();
-        _formatter.Received(0).Decode(Arg.Any<string>());
+        _formatter.Received(0).Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         Func<Task> act = async () => await Sut.FetchTask;
         await act.Should().NotCompleteWithinAsync(_pollInterval.Multiply(5));
         _cancellationTokenSource.Cancel();
-        _formatter.Received(0).Decode(Arg.Any<string>());
+        _formatter.Received(0).Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         Func<Task> act = async () => await Sut.FetchTask;
         await act.Should().NotCompleteWithinAsync(500.Microseconds());
         _cancellationTokenSource.Cancel();
-        _formatter.Received(0).Decode(Arg.Any<string>());
+        _formatter.Received(0).Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -86,7 +86,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         {
             ex.Should().BeOfType<TaskCanceledException>();
         }
-        _formatter.Received(0).Decode(Arg.Any<string>());
+        _formatter.Received(0).Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -108,7 +108,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         Func<Task> act = async () => await Sut.FetchTask;
         await act.Should().NotCompleteWithinAsync(_pollInterval.Multiply(5));
         _cancellationTokenSource.Cancel();
-        _formatter.Received(0).Decode(Arg.Any<string>());
+        _formatter.Received(0).Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -116,7 +116,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
     {
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), new[] { new NameValueEntry(_fieldName, _fixture.Create<string>()) }) };
         var decodeCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _formatter.Decode(Arg.Any<string>()).Returns(_ =>
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(_ =>
         {
             decodeCalled.TrySetResult(true);
             return default(ICacheEvent?);
@@ -128,7 +128,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         _cancellationTokenSource.Cancel();
         await fetchTask.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
 
-        _formatter.Received().Decode(Arg.Any<string>());
+        _formatter.Received().Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -136,7 +136,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
     {
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), new[] { new NameValueEntry(_fieldName, _fixture.Create<string>()) }) };
         var decodeCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _formatter.Decode(Arg.Any<string>()).Returns(_ =>
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(_ =>
         {
             decodeCalled.TrySetResult(true);
             return new TestCacheEvent { Valid = false };
@@ -148,7 +148,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         _cancellationTokenSource.Cancel();
         await fetchTask.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
 
-        _formatter.Received().Decode(Arg.Any<string>());
+        _formatter.Received().Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -156,7 +156,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
     {
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), new[] { new NameValueEntry(_fieldName, _fixture.Create<string>()) }) };
         var decodeCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _formatter.Decode(Arg.Any<string>()).Returns(_ =>
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(_ =>
         {
             decodeCalled.TrySetResult(true);
             return new TestCacheEvent { Valid = true };
@@ -168,14 +168,14 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         _cancellationTokenSource.Cancel();
         await fetchTask.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
 
-        _formatter.Received().Decode(Arg.Any<string>());
+        _formatter.Received().Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
     public async Task StreamReadGroupAsync_valid_event_subject_exception()
     {
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), new[] { new NameValueEntry(_fieldName, _fixture.Create<string>()) }) };
-        _formatter.Decode(Arg.Any<string>()).Returns(new TestCacheEvent
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(new TestCacheEvent
         {
             Valid = true,
         });
@@ -185,7 +185,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         Func<Task> act = async () => await Sut.FetchTask;
         await act.Should().NotCompleteWithinAsync(_pollInterval.Multiply(100));
         _cancellationTokenSource.Cancel();
-        _formatter.Received().Decode(Arg.Any<string>());
+        _formatter.Received().Decode(Arg.Any<ReadOnlyMemory<byte>>());
     }
 
     [Fact]
@@ -265,7 +265,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         // Decode throwing inside ProcessEvent must hit the outer catch (LogOnMessageError) so the
         // fetch loop doesn't blow up on a single malformed message.
         var decodeCalled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        _formatter.Decode(Arg.Any<string>()).Returns<ICacheEvent?>(_ =>
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns<ICacheEvent?>(_ =>
         {
             decodeCalled.TrySetResult(true);
             throw new InvalidOperationException("decode boom");
@@ -288,7 +288,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         _database.StreamAcknowledgeAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<RedisValue[]>())
             .Returns(_ => { ackCalled.TrySetResult(true); return Task.FromResult(1L); });
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), [new NameValueEntry(_fieldName, _fixture.Create<string>())]) };
-        _formatter.Decode(Arg.Any<string>()).Returns(new TestCacheEvent { Valid = true, Source = _sourceUri });
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(new TestCacheEvent { Valid = true, Source = _sourceUri });
         SetupSingleBatch(entries);
 
         using var sut = CreateSut(channel.Writer, _logger);
@@ -309,7 +309,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
             .Returns(_ => { ackCalled.TrySetResult(true); return Task.FromResult(1L); });
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), [new NameValueEntry(_fieldName, _fixture.Create<string>())]) };
         var ev = new TestCacheEvent { Valid = true, Source = new Uri("urn:other-source") };
-        _formatter.Decode(Arg.Any<string>()).Returns(ev);
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(ev);
         SetupSingleBatch(entries);
 
         using var sut = CreateSut(channel.Writer, _logger);
@@ -331,7 +331,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         var loggedClosed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         recordingLogger.OnRecord = r => { if (r.Message.Contains("Channel closed during dispatch")) loggedClosed.TrySetResult(true); };
         var entries = new[] { new StreamEntry(_fixture.Create<string>(), [new NameValueEntry(_fieldName, _fixture.Create<string>())]) };
-        _formatter.Decode(Arg.Any<string>()).Returns(new TestCacheEvent { Valid = true, Source = new Uri("urn:other-source") });
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(new TestCacheEvent { Valid = true, Source = new Uri("urn:other-source") });
         SetupSingleBatch(entries);
 
         using var sut = CreateSut(channel.Writer, recordingLogger);
@@ -357,7 +357,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
             new StreamEntry(firstId, [new NameValueEntry(_fieldName, _fixture.Create<string>())]),
             new StreamEntry(secondId, [new NameValueEntry(_fieldName, _fixture.Create<string>())]),
         };
-        _formatter.Decode(Arg.Any<string>()).Returns(new TestCacheEvent { Valid = true, Source = new Uri("urn:other-source") });
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(new TestCacheEvent { Valid = true, Source = new Uri("urn:other-source") });
         SetupSingleBatch(entries);
 
         using var sut = CreateSut(channel.Writer, _logger);
@@ -387,7 +387,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
             }
         };
         var entries = new[] { new StreamEntry(streamEntryId, [new NameValueEntry(_fieldName, _fixture.Create<string>())]) };
-        _formatter.Decode(Arg.Any<string>()).Returns(new TestCacheEvent { Id = eventId, Valid = true, Source = new Uri("urn:other-source") });
+        _formatter.Decode(Arg.Any<ReadOnlyMemory<byte>>()).Returns(new TestCacheEvent { Id = eventId, Valid = true, Source = new Uri("urn:other-source") });
         SetupSingleBatch(entries);
 
         using var sut = CreateSut(throwingWriter, recordingLogger);

--- a/tests/UiPath.Caching.Tests/SystemJsonSerializerProxyTests.cs
+++ b/tests/UiPath.Caching.Tests/SystemJsonSerializerProxyTests.cs
@@ -1,0 +1,44 @@
+using System.Text.Json;
+using StackExchange.Redis;
+
+namespace UiPath.Caching.Tests;
+
+public class SystemJsonSerializerProxyTests
+{
+    private sealed record Sample(int Id, string Name, int[] Values);
+
+    private readonly SystemJsonSerializerProxy _proxy = new();
+
+    [Fact]
+    public void RoundTrips_complex_object()
+    {
+        var original = new Sample(42, "héllo 世界", [1, 2, 3]);
+
+        var result = _proxy.Deserialize<Sample>(_proxy.Serialize(original));
+
+        result.Should().BeEquivalentTo(original);
+    }
+
+    [Fact]
+    public void Serialize_produces_utf8_json_on_the_wire()
+    {
+        var value = new Sample(1, "x", []);
+
+        ((byte[])_proxy.Serialize(value)!).Should().Equal(JsonSerializer.SerializeToUtf8Bytes(value));
+    }
+
+    [Fact]
+    public void Deserializes_value_written_by_the_legacy_string_path()
+    {
+        RedisValue legacy = JsonSerializer.Serialize(new Sample(7, "legacy", [9]));
+
+        _proxy.Deserialize<Sample>(legacy).Should().BeEquivalentTo(new Sample(7, "legacy", [9]));
+    }
+
+    [Fact]
+    public void Null_and_empty_return_default()
+    {
+        _proxy.Deserialize<Sample>(RedisValue.Null).Should().BeNull();
+        _proxy.Deserialize<Sample>(RedisValue.EmptyString).Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

JSON is UTF-8 on the wire, but the cache serializer round-tripped every payload through a UTF-16 `string`, adding an allocation + transcode on every read and write. This keeps serialization on UTF-8 bytes end-to-end, enabled by StackExchange.Redis 3.0's `RedisValue` ↔ `ReadOnlyMemory`/`ReadOnlySequence<byte>` conversions. **No public API change** beyond two `[Obsolete]` markers; wire format is unchanged so existing cached/published data still deserializes.

> Stacked on #86 (needs SE.Redis 3.0). Merge #85 → #86 first; this retargets to `main` afterward.

## Changes

- **`SystemJsonSerializerProxy`** (the default proxy, shared by `RedisCache`, `RedisHashCache`, `RedisSetCache`, `RedisCacheProvider` — all inherit the win): serialize via `SerializeToUtf8Bytes`; deserialize from the `RedisValue` payload as `ReadOnlySpan<byte>`; deserialize a `JsonElement` directly instead of via `GetRawText()`.
- **Broadcast**: `CacheEventFormatter.Encode` uses `SerializeToUtf8Bytes`; the publish paths (`RedisPubSubTopic`, `RedisStreamsTopic`) publish the encoded bytes as a `RedisValue` directly; the subscribe paths (`RedisPubSubSubjectWriter`, `RedisStreamSubjectWriter`) decode from the `RedisValue` bytes.
- **Deprecated**: `IEventFormatterProxy<T>.Decode(string)` and `EncodeAsString(T)` (now unused by the library — they forced a UTF-16 transcode). Stream-subject-writer tests migrated to the `ReadOnlyMemory<byte>` overload.

## Benchmark

New `SerializerBenchmark` (`[MemoryDiagnoser]`). Allocation numbers are exact/reliable; roughly **halved** on both paths:

| Case | string (baseline) | bytes | 
|---|---|---|
| Deserialize Large | 1,385,629 B | **607,714 B (0.44×)** |
| Deserialize Medium | 3,368 B | **1,736 B (0.52×)** |
| Serialize Large | 778,689 B | **389,660 B (0.50×)** |
| Serialize Medium | 1,944 B | **1,144 B (0.59×)** |

The benchmark also measured a `ReadOnlySequence<byte>`/`Utf8JsonReader` read variant; it allocated identically to the span path but ran **slower** on these single-segment payloads, so the span path was chosen. (Run: `dotnet run -c Release --framework net10.0 --project benchmarks/UiPath.Caching.Benchmarks -- --filter *SerializerBenchmark*`)

## Test plan

- [x] Unit tests added/updated (`SystemJsonSerializerProxyTests` incl. legacy string-path round-trip; broadcast tests migrated)
- [x] Integration tests pass locally (`dotnet test`)
- [x] CHANGELOG.md updated

Full suite green on **net8.0** and **net10.0** — **1178/1178 each** — with `RUN_REDIS_INTEGRATION_TESTS=1` against a live Redis.

## Linked issues

Fixes #

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)