### PR TITLE
chore(tests): clear all build warnings

### DIFF
--- a/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubTopicTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisPubSubTopicTests.cs
@@ -240,7 +240,7 @@ public class RedisPubSubTopicTests(ITestContextAccessor testContextAccessor) : I
         _subscriber = _fixture.Freeze<ISubscriber>();
         _observer = _fixture.Freeze<IObserver<ICacheEvent>>();
         _observer.When(x => x.OnNext(Arg.Any<ICacheEvent>()))
-            .Do(c => _onNextMessages.Add(c.Arg<ICacheEvent>()));
+            .Do(c => _onNextMessages.Add(c.Arg<ICacheEvent>()!));
         _observer.When(x => x.OnCompleted())
             .Do(c => _onCompleted = true);
         _subscriber.When(x => x.Subscribe(Arg.Any<RedisChannel>(), Arg.Any<Action<RedisChannel, RedisValue>>(), Arg.Any<CommandFlags>()))

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamNotifyChannelTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamNotifyChannelTests.cs
@@ -21,7 +21,7 @@ public class RedisStreamNotifyChannelTests
 
         var captured = new TaskCompletionSource<Action<RedisChannel, RedisValue>>(TaskCreationOptions.RunContinuationsAsynchronously);
         subscriber.When(s => s.Subscribe(channel, Arg.Any<Action<RedisChannel, RedisValue>>()))
-            .Do(ci => captured.TrySetResult(ci.Arg<Action<RedisChannel, RedisValue>>()));
+            .Do(ci => captured.TrySetResult(ci.Arg<Action<RedisChannel, RedisValue>>()!));
 
         using var waiter = new SignalingFetchWaiter(5.Seconds());
         using var sut = new RedisStreamNotifyChannel(channel, redis, _fixture.Create<ILogger>(), waiter, null, 10.Milliseconds());

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
@@ -349,7 +349,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         var channel = Channel.CreateBounded<ICacheEvent>(new BoundedChannelOptions(1));
         var ackCalled = new TaskCompletionSource<RedisValue[]>(TaskCreationOptions.RunContinuationsAsynchronously);
         _database.StreamAcknowledgeAsync(Arg.Any<RedisKey>(), Arg.Any<RedisValue>(), Arg.Any<RedisValue[]>())
-            .Returns(ci => { ackCalled.TrySetResult(ci.Arg<RedisValue[]>()); return Task.FromResult(1L); });
+            .Returns(ci => { ackCalled.TrySetResult(ci.Arg<RedisValue[]>()!); return Task.FromResult(1L); });
         var firstId = _fixture.Create<string>();
         var secondId = _fixture.Create<string>();
         var entries = new[]

--- a/tests/UiPath.Caching.Tests/MultilayerCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/MultilayerCacheTests.cs
@@ -67,7 +67,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
     public async Task Multi_get_does_not_call_inner_ExpireTimeAsync_separately()
     {
         var expected = _fixture.Create<string>();
-        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k.Contains(_innerCacheKey) && k.Contains(_innerMultiKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k != null && k.Contains(_innerCacheKey) && k.Contains(_innerMultiKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(new KeyValuePair<CacheKey, ICacheEntry<string?>>[]
             {
                 new(_innerCacheKey, new TestCacheEntry<string?> { Value = expected, Expiration = _fixture.Create<DateTimeOffset>() }),
@@ -110,7 +110,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
     public async Task Multi_get_data_from_inner_cache()
     {
         var expected = _fixture.Create<string>();
-        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k.Contains(_innerCacheKey) && k.Contains(_innerMultiKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k != null && k.Contains(_innerCacheKey) && k.Contains(_innerMultiKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(new KeyValuePair<CacheKey, ICacheEntry<string?>>[]
             {
                 new(_innerCacheKey, new TestCacheEntry<string?> { Value = expected }),
@@ -612,7 +612,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
         var actual = await Sut.SetAsync(new KeyValuePair<CacheKey, string?>[] { new ( _cacheKey, default(string) ), new ( _multiKey, default(string) ) }, _fixture.Create<TimeSpan>(), policy: null, token: testContextAccessor.Current.CancellationToken);
         _memoryCache.Received(1).Remove(_innerCacheKey);
         _memoryCache.Received(1).Remove(_innerMultiKey);
-        await _innerCache.Received(1).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
+        await _innerCache.Received(1).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c != null && c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
         await _topic.Received(2).PublishAsync(Arg.Any<ICacheEvent>(), Arg.Any<CancellationToken>());
     }
 
@@ -629,7 +629,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
         var actual = await Sut.SetAsync(new KeyValuePair<CacheKey, string?>[] { new(_cacheKey, default(string)), new(_multiKey, default(string)) }, policy: null, token: testContextAccessor.Current.CancellationToken);
         _memoryCache.Received(1).Remove(_innerCacheKey);
         _memoryCache.Received(1).Remove(_innerMultiKey);
-        await _innerCache.Received(1).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
+        await _innerCache.Received(1).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c != null && c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
         await _topic.Received(2).PublishAsync(Arg.Any<ICacheEvent>(), Arg.Any<CancellationToken>());
     }
 
@@ -647,7 +647,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
         var actual = await Sut.SetAsync(new KeyValuePair<CacheKey, string?>[] { new(_cacheKey, value), new(_multiKey, value) }, _fixture.Create<TimeSpan>(), policy: null, token: testContextAccessor.Current.CancellationToken);
         _memoryCache.Received(0).Remove(_innerCacheKey);
         _memoryCache.Received(0).Remove(_innerMultiKey);
-        await _innerCache.Received(0).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c.Contains(_innerMultiKey) || c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
+        await _innerCache.Received(0).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c != null && (c.Contains(_innerMultiKey) || c.Contains(_innerCacheKey))), Arg.Any<CancellationToken>());
         _memoryCache.Received(1).CreateEntry(_innerCacheKey);
         _memoryCache.Received(1).CreateEntry(_innerMultiKey);
         await _topic.Received(2).PublishAsync(Arg.Any<ICacheEvent>(), Arg.Any<CancellationToken>());
@@ -792,12 +792,12 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
         _innerCache.GetAsync<string>(_innerMultiKey, Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(default(string?));
 
-        _innerCache.RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), testContextAccessor.Current.CancellationToken)
+        _innerCache.RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c != null && c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), testContextAccessor.Current.CancellationToken)
             .Returns(_ => removed);
         _topic.PublishAsync(Arg.Any<ICacheEvent>(), Arg.Any<CancellationToken>())
             .Returns(_ => eventPublished);
         var actual = await Sut.RemoveAsync<string>(new CacheKey[] { _cacheKey, _multiKey }, token: testContextAccessor.Current.CancellationToken);
-        await _innerCache.Received(1).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
+        await _innerCache.Received(1).RemoveAsync<string>(Arg.Is<CacheKey[]>(c => c != null && c.Contains(_innerMultiKey) && c.Contains(_innerCacheKey)), Arg.Any<CancellationToken>());
         
         if (removed)
         {
@@ -821,7 +821,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
         }));
 
         var expected = _fixture.Create<string>();
-        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k.Contains(_innerCacheKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k != null && k.Contains(_innerCacheKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(new KeyValuePair<CacheKey, ICacheEntry<string?>>[]
             {
                 new(_innerCacheKey, new TestCacheEntry<string?> { Value = expected })
@@ -851,7 +851,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
 
         var expected = _fixture.Create<string>();
 
-        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k.Contains(_innerCacheKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k != null && k.Contains(_innerCacheKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(new KeyValuePair<CacheKey, ICacheEntry<string?>>[]
             {
                 new(_innerCacheKey, new TestCacheEntry<string?> { Value = expected, Expiration = _clock.UtcNow.AddDays(1) })
@@ -881,7 +881,7 @@ public class MultilayerCacheTests(ITestContextAccessor testContextAccessor) : IA
         }));
 
         var expected = _fixture.Create<string>();
-        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k.Contains(_innerCacheKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+        _innerCache.GetCacheEntriesAsync<string>(Arg.Is<CacheKey[]>(k => k != null && k.Contains(_innerCacheKey)), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
             .Returns(new KeyValuePair<CacheKey, ICacheEntry<string?>>[]
             {
                 new(_innerCacheKey, new TestCacheEntry<string?> { Value = expected, Expiration = now.AddDays(1) })

--- a/tests/UiPath.Caching.Tests/Redis/RedisCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisCacheTests.cs
@@ -75,7 +75,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     public async Task Multi_get_works_as_expected()
     {
         var expectedValue = _fixture.Create<string>();
-        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(ci =>
             {
                 return new RedisValue[] { _serializer.Serialize(expectedValue), _serializer.Serialize(expectedValue) };
@@ -137,7 +137,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     [Fact]
     public async Task Multi_get_emits_one_metric_per_operation_with_key_count()
     {
-        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()), RedisValue.Null });
 
         await Sut.GetAsync<string>(new CacheKey[] { _cacheKey, _multiKey }, policy: null, token: testContextAccessor.Current.CancellationToken);
@@ -163,7 +163,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     [Fact]
     public async Task Multi_get_returns_defaults_when_value_array_is_partial()
     {
-        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()) });
 
         var actual = await Sut.GetAsync<string>(new CacheKey[] { _cacheKey, _multiKey }, policy: null, token: testContextAccessor.Current.CancellationToken);
@@ -199,7 +199,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     [Fact]
     public async Task GetCacheEntries_emits_one_metric_per_operation_with_key_count()
     {
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()), RedisValue.Null });
         _transaction.KeyTimeToLiveAsync(Arg.Any<RedisKey>(), CommandFlags.PreferReplica)
             .Returns(TimeSpan.FromMinutes(15));
@@ -243,7 +243,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     [Fact]
     public async Task Multi_get_does_not_carry_keys_by_default()
     {
-        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()), RedisValue.Null });
 
         await Sut.GetAsync<string>(new CacheKey[] { _cacheKey, _multiKey }, policy: null, token: testContextAccessor.Current.CancellationToken);
@@ -255,7 +255,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     public async Task Multi_get_carries_key_per_hit_and_miss_when_opt_in()
     {
         _cacheOptions.KeyReadTelemetryEnabled = true;
-        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _database.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()), RedisValue.Null });
 
         await Sut.GetAsync<string>(new CacheKey[] { _cacheKey, _multiKey }, policy: null, token: testContextAccessor.Current.CancellationToken);
@@ -268,7 +268,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     public async Task GetCacheEntries_carries_key_per_hit_and_miss_when_opt_in()
     {
         _cacheOptions.KeyReadTelemetryEnabled = true;
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()), RedisValue.Null });
         _transaction.KeyTimeToLiveAsync(Arg.Any<RedisKey>(), CommandFlags.PreferReplica)
             .Returns(TimeSpan.FromMinutes(15));
@@ -348,7 +348,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     {
         var expected = _fixture.Create<string>();
         var expectedTtl = TimeSpan.FromMinutes(15);
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(expected), _serializer.Serialize(expected) });
         _transaction.KeyTimeToLiveAsync(Arg.Any<RedisKey>(), CommandFlags.PreferReplica)
             .Returns(expectedTtl);
@@ -441,7 +441,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     [Fact]
     public async Task GetCacheEntries_returns_defaults_and_records_miss_when_a_per_key_subtask_throws()
     {
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(_fixture.Create<string>()), _serializer.Serialize(_fixture.Create<string>()) });
         _transaction.KeyTimeToLiveAsync(_redisKey, CommandFlags.PreferReplica).Returns(TimeSpan.FromMinutes(5));
         _transaction.KeyTimeToLiveAsync(_redisMultiKey, CommandFlags.PreferReplica).ThrowsAsync(new RedisException("ttl boom"));
@@ -503,7 +503,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
         _version = new(7, 0);
         var expected = _fixture.Create<string>();
         var expectedExpiration = DateTimeOffset.UtcNow.AddMinutes(15);
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { _serializer.Serialize(expected), _serializer.Serialize(expected) });
         _transaction.KeyExpireTimeAsync(Arg.Any<RedisKey>(), CommandFlags.PreferReplica)
             .Returns(expectedExpiration.UtcDateTime);
@@ -837,7 +837,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     [Fact]
     public async Task Multi_remove_redis_exception()
     {
-        _database.KeyDeleteAsync(Arg.Is<RedisKey[]>(keys => keys.Contains(_redisKey )), CommandFlags.DemandMaster)
+        _database.KeyDeleteAsync(Arg.Is<RedisKey[]>(keys => keys != null && keys.Contains(_redisKey )), CommandFlags.DemandMaster)
                 .ThrowsAsync(ci =>
                 {
                     return new RedisException("test");
@@ -1121,7 +1121,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
         _cacheOptions.CacheNullValues = true;
         var expectedValue = _fixture.Create<string>();
         var expectedTtl = TimeSpan.FromMinutes(15);
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { RedisValue.EmptyString, _serializer.Serialize(expectedValue) });
         _transaction.KeyTimeToLiveAsync(Arg.Any<RedisKey>(), CommandFlags.PreferReplica).Returns(expectedTtl);
         _transaction.ExecuteAsync(Arg.Any<CommandFlags>()).Returns(true);
@@ -1140,7 +1140,7 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     public async Task GetCacheEntriesAsync_returns_miss_for_empty_value_when_CacheNullValues_false()
     {
         _cacheOptions.CacheNullValues = false;
-        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
+        _transaction.StringGetAsync(Arg.Is<RedisKey[]>(k => k != null && k.Contains(_redisKey) && k.Contains(_redisMultiKey)), CommandFlags.PreferReplica)
             .Returns(new RedisValue[] { RedisValue.EmptyString, RedisValue.EmptyString });
         _transaction.KeyTimeToLiveAsync(Arg.Any<RedisKey>(), CommandFlags.PreferReplica).Returns(TimeSpan.FromMinutes(15));
         _transaction.ExecuteAsync(Arg.Any<CommandFlags>()).Returns(true);

--- a/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
+++ b/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SonarQubeTestProject>true</SonarQubeTestProject>
+    <!-- AutoFixture.AutoNSubstitute 4.18.1 caps NSubstitute at <6, but 6.0.0 is used and passes; the pin is intentional. -->
+    <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Drives the solution to a **warning-free build** (0 warnings, down from 104 CS8604 + 6 NU1608). Test/build hygiene only — no product code changes.

## Changes

- **CS8604** (possible null reference argument — 26 unique test sites in `RedisCacheTests`, `MultilayerCacheTests`, `RedisPubSubTopicTests`, `RedisStreamNotifyChannelTests`, `RedisStreamSubjectWriterTests`):
  - NSubstitute `Arg.Is<T[]>(k => k.Contains(...))` matcher lambdas receive a **nullable** parameter, so the predicates now guard with `k != null && ...` before `.Contains` — matching the convention already used elsewhere in these files (e.g. `MultilayerCacheTests` lines 169/1004).
  - `CallInfo.Arg<T>()` values passed to `List.Add` / `TaskCompletionSource.TrySetResult` use the null-forgiving operator (`!`).
- **NU1608**: `AutoFixture.AutoNSubstitute 4.18.1` caps `NSubstitute` at `< 6.0.0`, but the pin is `6.0.0` (the latest stable) and passes all tests. **No** `AutoFixture.AutoNSubstitute` version — including `5.0.0-preview` — yet permits NSubstitute 6, so the constraint notice is suppressed in the test project (`NoWarn`) with a justifying comment, rather than downgrading off the latest NSubstitute.

## Test plan

- [x] Unit tests added/updated <!-- adjusted existing tests only -->
- [x] Integration tests pass locally (`dotnet test`)
- [ ] CHANGELOG.md updated <!-- test/build only, no product change -->

Full suite green on **net8.0** and **net10.0** (**1182/1182** each), and a forced rebuild (`--no-incremental`) emits **0 warnings**.

## Linked issues

Fixes #

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)