### PR TITLE
chore(deps): bump OpenTelemetry family from 1.16.0 to 1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped the OpenTelemetry package family from 1.16.0 to 1.17.0 (`OpenTelemetry`, `OpenTelemetry.Exporter.OpenTelemetryProtocol`, `OpenTelemetry.Exporter.Console`, `OpenTelemetry.Extensions.Hosting`, `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Http`, `OpenTelemetry.Instrumentation.Runtime`, and `OpenTelemetry.Instrumentation.StackExchangeRedis` 1.16.0-beta.1 → 1.17.0-beta.1). Bumped as one set so the family stays version-consistent.
+
 ## [1.1.0] - 2026-07-17
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -49,14 +49,14 @@
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="$(CloudEvents)" />
     <PackageVersion Include="Polly.Core" Version="8.7.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.7.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.16.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.17.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <!-- Public API surface tracking (src libraries only; wired in src/Directory.Build.props) -->


### PR DESCRIPTION
## Summary

Consolidates the five individual Dependabot OpenTelemetry bumps (#98–#102) into a single PR, and bumps the **entire** OpenTelemetry family from `1.16.0` → `1.17.0` so it stays version-consistent — including the three packages Dependabot did *not* open PRs for.

## Bumped (`Directory.Packages.props`)

| Package | From | To |
|---|---|---|
| OpenTelemetry | 1.16.0 | 1.17.0 |
| OpenTelemetry.Exporter.OpenTelemetryProtocol | 1.16.0 | 1.17.0 |
| OpenTelemetry.Exporter.Console | 1.16.0 | 1.17.0 |
| OpenTelemetry.Extensions.Hosting | 1.16.0 | 1.17.0 |
| OpenTelemetry.Instrumentation.AspNetCore | 1.16.0 | 1.17.0 |
| OpenTelemetry.Instrumentation.Http | 1.16.0 | 1.17.0 |
| OpenTelemetry.Instrumentation.Runtime | 1.16.0 | 1.17.0 |
| OpenTelemetry.Instrumentation.StackExchangeRedis | 1.16.0-beta.1 | 1.17.0-beta.1 |

`Console`, `Instrumentation.Runtime`, and `Instrumentation.StackExchangeRedis` weren't covered by Dependabot — bumping them here keeps the family from splitting across 1.16/1.17.

## Test plan

- [x] Full solution + `UiPath.Caching.Sample` build clean (Release), no `NU1605`/`NU1608` version-conflict warnings
- [x] Test suite green on net8.0 and net10.0 (1220 passed; integration tests skipped without a live Redis)
- [x] CHANGELOG.md updated

Supersedes and closes #98, #99, #100, #101, #102.

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)