### PR TITLE
fix(broadcast): stop hammering backends without XREADGROUP, honor BroadcastEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   nodes refresh each shared key once. Added to `ICache` as default interface methods, so existing
   `ICache` implementations keep compiling; the `ICache<T>` overloads are **abstract** — see the
   breaking note under **Changed**.
+- **`InMemoryRedisCacheOptions.BroadcastEnable`** (default `true`) turns cross-node L1 invalidation off for the `InMemoryRedis` provider alone, so L1+L2 tiering can be used without broadcast traffic. Intended for single-node deployments, where cross-node invalidation buys nothing, and for Redis-compatible backends whose Streams support does not cover `XREADGROUP`. When `false` the provider gets `NullTopicFactory` / `NullChangeTokenFactory` / `NullCacheEventFactory`, mirroring what `InMemoryCacheProvider` already did for `InMemoryCacheOptions.BroadcastEnable`. The flag can only narrow `CacheOptions.BroadcastEnabled`, never widen it; note its default is the opposite of the `InMemory` equivalent, which is opt-in. ([#103](https://github.com/UiPath/dotnet-caching/issues/103))
 
 ### Changed
 
@@ -37,6 +38,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   `UiPath.Caching.Abstractions`, with no recompile involved. Consumers that pick the new abstractions
   up transitively must rebuild, not just restore. The `ICache` overloads are default interface
   methods, so `ICache` implementations are unaffected.
+
+### Fixed
+
+- The Redis Streams fetch loop no longer hammers a server that does not implement `XREADGROUP`. It previously re-issued the command and logged `Fetch events loop error` once per `PollInterval` (250 ms by default) forever. The unsupported-command case is now reported once at `Critical` with the available remedies, then retried every 30 s; a successful fetch lifts the quarantine and logs recovery, and a connection-restored/reconnected event wakes the loop early so recovery does not wait out the backoff. Recovery does not depend on those events: with the connection monitor off (the default) the timed retry still gets there. Other consecutive fetch failures now back off exponentially from `PollInterval` up to 30 s instead of retrying at the poll rate. ([#103](https://github.com/UiPath/dotnet-caching/issues/103))
+- **`CacheOptions.BroadcastEnabled` now actually disables broadcast.** It was read only by `RedisStreamHealthMaintainer`, so setting it through the `AddCaching` options lambda stopped the maintainer while the Streams fetch loop kept running, despite sharing a name with the configuration key that does perform the real opt-out. `TopicFactory` now resolves every topic to `NullTopicProvider` and reports no provider names when the flag is `false`. ([#103](https://github.com/UiPath/dotnet-caching/issues/103))
+
+### Documentation
+
+- `concepts.md` now states that `AddInMemoryRedis()` wires broadcast internally and that a code-only `AddBroadcast(enabled: false)` does not stick, and links to the broadcast how-to. The how-to gains a section on disabling broadcast for `InMemoryRedis` alone and a troubleshooting entry for `ERR unknown command` against Redis-compatible backends. ([#103](https://github.com/UiPath/dotnet-caching/issues/103))
 
 ## [1.2.0] - 2026-08-04
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -38,6 +38,13 @@ any application-level plumbing. The higher-level concepts of L1/L2 tiers and
 topics are described in their own sections below; what matters here is that
 `InMemoryRedis` is the composition that ties them together.
 
+"Automatically" is literal: `AddInMemoryRedis()` calls `AddBroadcast()` for you, so
+broadcast is on whether or not you call `AddBroadcast()` yourself, and a code-only
+`AddBroadcast(enabled: false)` does not stick. To turn it off, or to keep L1+L2 while
+using a transport other than Redis Streams (which matters against Redis-compatible
+backends that lack `XREADGROUP`), see
+[how-to/broadcast.md](how-to/broadcast.md#enabling-and-disabling-broadcast).
+
 `Redis` is the provider to choose when you want every read and write to go
 straight to Redis and never be fronted by an in-process copy. The typical reason
 is footprint: if cached values are large or numerous enough that duplicating them

--- a/docs/how-to/broadcast.md
+++ b/docs/how-to/broadcast.md
@@ -26,6 +26,27 @@ Broadcast is wired up by calling `AddBroadcast()` on the caching builder. The no
 
 When broadcast is disabled via `BroadcastEnabled: false`, neither `RedisStreamsTopicProvider` nor `RedisPubSubTopicProvider` is registered. All `ITopic` resolutions fall through to the null implementation — writes go to Redis and L1 but no invalidation messages are sent or received. This is safe for single-node deployments and for development environments where a second Redis connection for streams is undesirable.
 
+The same key also exists as a runtime property, `CacheOptions.BroadcastEnabled`, settable from the `AddCaching` options lambda. Setting it to `false` makes `TopicFactory` resolve every topic to `NullTopicProvider`, so broadcast goes quiet even when the providers were already registered. Prefer the configuration key when you can: it skips the registration altogether rather than neutering it afterwards.
+
+### Disabling broadcast for `InMemoryRedis` only
+
+`InMemoryRedisCacheOptions.BroadcastEnable` turns broadcast off for that one provider while leaving it on for everything else:
+
+```jsonc
+"Caching": {
+  "InMemoryRedis": {
+    "BroadcastEnable": false   // L1+L2 tiering, no cross-node invalidation
+  }
+}
+```
+
+Use it when a single provider should skip broadcast: a single-node deployment where cross-node invalidation buys nothing, or a Redis-compatible backend whose Streams support does not cover `XREADGROUP` (Garnet, for example) and you would rather drop invalidation than switch transport.
+
+Two things to know:
+
+- It defaults to `true`, the opposite of `InMemoryCacheOptions.BroadcastEnable`, which is opt-in. `InMemoryRedis` has always broadcast by default and continues to.
+- It can only narrow the app-wide setting. The effective behavior is `CacheOptions.BroadcastEnabled` AND this flag, so when broadcast is off app-wide, setting this to `true` changes nothing.
+
 ## Choosing a transport
 
 `AddBroadcast()` calls both `AddRedisStreams()` and `AddRedisPubSub()` — which provider actually handles a topic depends on whether its `Enabled` flag is `true`. By default Redis Streams is enabled and Pub/Sub is disabled (`RedisPubSubTopicOptions.Enabled` defaults to `false`).
@@ -330,6 +351,14 @@ Confirm `MaintainerEnabled: true` and that `StartAsync` was called (the service 
 **Consumer groups from decommissioned pods accumulate.**
 
 These are cleaned up by the maintainer's quarantine logic. A group with no consumers is quarantined on the first cycle it is observed and deleted after `MaintainerQuarantineInterval` (default 1 h). If groups are accumulating faster than they are being cleaned up, lower `MaintainerCheckInterval` to run maintenance more frequently.
+
+**`ERR unknown command` from the fetch loop against a Redis-compatible backend.**
+
+The server does not implement `XREADGROUP`. Some RESP-compatible stores support Streams writes and ranges without the consumer-group read side; Microsoft Garnet is the common case. The fetch loop reports this once at `Critical` and then retries every 30 s instead of once per `PollInterval`, so the log does not flood, and it recovers on its own if the connection later lands on a server that does support the command. Until then this node receives no invalidations over Streams.
+
+Three ways out, in order of preference: switch to Pub/Sub (see [Choosing a transport](#choosing-a-transport)), which those backends do support and which keeps cross-node invalidation; set `InMemoryRedis:BroadcastEnable: false` to keep L1+L2 without invalidation; or disable broadcast app-wide with `BroadcastEnabled: false`.
+
+Note that `RedisStreams:Enabled: false` is worth setting alongside either of the last two, otherwise `RedisStreamHealthMaintainer` still starts and runs `SCAN`/`XINFO` against the same backend.
 
 **`MaintainerSearchPattern` warning: SCAN is matching keys outside this app.**
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -142,6 +142,7 @@ Per-topic overrides: add entries to `Topics[]` under `Broadcast:RedisPubSub`. Ea
 | `Timeout` | `TimeSpan` | `00:00:01` | Per-provider | Max wait for a cache operation before giving up and falling through. |
 | `TrackStatistics` | `bool` | `true` | Per-provider | Emit hit/miss/eviction counters via the telemetry provider. |
 | `StatisticsFlushInterval` | `TimeSpan` | `00:01:00` | Per-provider | How often statistics are flushed to the telemetry sink. |
+| `BroadcastEnable` | `bool` | `true` | Per-provider | Publish/consume cross-node L1 invalidations for this provider. `false` keeps L1+L2 with no broadcast traffic. Can only narrow `CacheOptions.BroadcastEnabled`, never widen it. Note the default is the opposite of `InMemoryCacheOptions.BroadcastEnable`. |
 | `Topic` | `string?` | `null` | Per-provider | Topic name for L1 invalidation broadcasts; `null` = use `CacheOptions.DefaultTopic`. |
 | `LocalMaxExpiration` | `TimeSpan?` | `null` | Per-provider | Cap on the L1 (in-memory) TTL while L2 is connected; `null` = no cap beyond `DefaultExpiration`. |
 | `ConnectionMonitorEnabled` | `bool?` | `null` | Per-provider | `null` = inherit from `CacheOptions.ConnectionMonitorEnabled`. |

--- a/samples/UiPath.Caching.Sample/appsettings.all.json
+++ b/samples/UiPath.Caching.Sample/appsettings.all.json
@@ -189,6 +189,8 @@
       "TrackStatistics": true,
       // StatisticsFlushInterval: how often statistics are flushed to telemetry
       "StatisticsFlushInterval": "0:01:00",
+      // BroadcastEnable: cross-node L1 invalidation for this provider; false = L1+L2 with no broadcast
+      "BroadcastEnable": true,
       // Topic: topic name for L1 invalidation broadcasts; null = use DefaultTopic
       "Topic": null,
       // TopicKeyStrategy: set in code; see how-to/telemetry-and-strategies.md

--- a/src/UiPath.Caching/Broadcast/Redis/RedisStreamSubjectWriter.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisStreamSubjectWriter.cs
@@ -1,4 +1,4 @@
-using System.Threading.Channels;
+﻿using System.Threading.Channels;
 using UiPath.Caching.Telemetry;
 
 namespace UiPath.Caching.Broadcast.Redis;
@@ -25,6 +25,9 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
     private readonly CancellationToken _cancelationToken;
     private readonly IFetchWaiter _waiter;
     private RedisValue _lastId = StreamPosition.NewMessages;
+    private readonly SemaphoreSlim _retryGate = new(0, 1);
+    private int _consecutiveFailures;
+    private volatile bool _unsupportedCommand;
 
     public RedisStreamSubjectWriter(
         RedisStreamContext context,
@@ -49,6 +52,8 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
         _waiter = waiter;
         _stopTokenSource = CancellationTokenSource.CreateLinkedTokenSource(stopToken);
         _cancelationToken = _stopTokenSource.Token;
+        _connectionState.OnReconnected += OnConnectionRecovered;
+        _connectionState.OnConnectionRestored += OnConnectionRecovered;
         FetchTask = Task.Run(FetchLoop, _cancelationToken);
     }
 
@@ -59,9 +64,35 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
             return;
         }
         _disposed = true;
+        _connectionState.OnReconnected -= OnConnectionRecovered;
+        _connectionState.OnConnectionRestored -= OnConnectionRecovered;
         _stopTokenSource?.Cancel();
         _stopTokenSource?.Dispose();
+        _retryGate.Dispose();
         _writer.TryComplete();
+    }
+
+    private void OnConnectionRecovered(object? sender, EventArgs e) => ReleaseRetryGate();
+
+    private void ReleaseRetryGate()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        try
+        {
+            _retryGate.Release();
+        }
+        catch (SemaphoreFullException)
+        {
+            // A wake-up is already pending; collapsing to one is the desired behavior.
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed concurrently; there is no loop left to wake.
+        }
     }
 
     internal Task FetchTask { get; }
@@ -119,6 +150,13 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
             StreamConstants.UndeliveredMessages,
             _context.PollBatchSize).ConfigureAwait(false);
 
+        _consecutiveFailures = 0;
+        if (_unsupportedCommand)
+        {
+            _unsupportedCommand = false;
+            LogStreamsSupportRecovered(_context.Topic);
+        }
+
         if (events.Length > 0)
         {
             await DispatchEventsAsync(events).ConfigureAwait(false);
@@ -135,6 +173,18 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
         {
             LogReadingStopped(_context.Topic, _context.ConsumerGroup, id);
             return false;
+        }
+
+        if (IsUnsupportedCommand(ex))
+        {
+            if (!_unsupportedCommand)
+            {
+                _unsupportedCommand = true;
+                LogStreamsUnsupported(ex, _context.Topic);
+            }
+
+            await WaitForRetryAsync(StreamConstants.MaxErrorBackoff).ConfigureAwait(false);
+            return true;
         }
 
         if (ex.Message.StartsWith("NOGROUP", StringComparison.OrdinalIgnoreCase))
@@ -163,8 +213,40 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
            LogFetchLoopError(ex);
         }
 
-        await _waiter.WaitAsync(_cancelationToken).ConfigureAwait(false);
+        await BackoffAsync().ConfigureAwait(false);
         return true;
+    }
+
+    private static bool IsUnsupportedCommand(Exception ex) =>
+        ex is RedisCommandException ||
+        (ex is RedisServerException &&
+         ex.Message.Contains(StreamConstants.UnknownCommandErrorMessage, StringComparison.OrdinalIgnoreCase));
+
+    private Task BackoffAsync()
+    {
+        var failures = ++_consecutiveFailures;
+        if (failures <= StreamConstants.ErrorBackoffThreshold)
+        {
+            return _waiter.WaitAsync(_cancelationToken);
+        }
+
+        var exponent = Math.Min(failures - StreamConstants.ErrorBackoffThreshold, 16);
+        var scaled = _context.PollInterval.Multiply(Math.Pow(2, exponent));
+        var delay = scaled > StreamConstants.MaxErrorBackoff ? StreamConstants.MaxErrorBackoff : scaled;
+        LogFetchLoopBackoff(failures, delay);
+        return WaitForRetryAsync(delay);
+    }
+
+    private async Task WaitForRetryAsync(TimeSpan delay)
+    {
+        try
+        {
+            await _retryGate.WaitAsync(delay, _cancelationToken).ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Disposed concurrently with the wait; treat as a wake-up so the loop observes disposal.
+        }
     }
 
     private async Task DispatchEventsAsync(StreamEntry[] events)
@@ -303,6 +385,17 @@ internal sealed partial class RedisStreamSubjectWriter<T> : IDisposable
 
     [LoggerMessage(Level = LogLevel.Error, Message = "Fetch events loop error")]
     private partial void LogFetchLoopError(Exception ex);
+
+    [LoggerMessage(
+        Level = LogLevel.Critical,
+        Message = "Redis Streams reads are not supported by the server for topic {Topic}. This node will not receive cross-node cache invalidations over Streams. Retrying slowly in case the connection moves to a server that supports XREADGROUP; to fix it now switch to Pub/Sub (DefaultTopic: RedisPubSub) or disable broadcast.")]
+    private partial void LogStreamsUnsupported(Exception ex, RedisKey topic);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Redis Streams reads recovered for topic {Topic}; resuming normal polling.")]
+    private partial void LogStreamsSupportRecovered(RedisKey topic);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Fetch events loop backing off for {Delay} after {Failures} consecutive failures")]
+    private partial void LogFetchLoopBackoff(int failures, TimeSpan delay);
 
     [LoggerMessage(Level = LogLevel.Trace, Message = "Event from current source. Id {EventId}  Topic : {Topic}, StreamId : {StreamId}")]
     private partial void LogEventFromCurrentSource(string? eventId, RedisKey topic, RedisValue streamId);

--- a/src/UiPath.Caching/Broadcast/Redis/StreamConstants.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/StreamConstants.cs
@@ -4,4 +4,26 @@ internal static class StreamConstants
 {
     internal static readonly RedisValue UndeliveredMessages = ">";
     internal const string ConsumerGroupNameExistsErrorMessage = "BUSYGROUP Consumer Group name already exists";
+
+    /// <summary>
+    /// Phrase a RESP server uses when it does not implement the command at all. Redis-compatible stores that
+    /// lack <c>XREADGROUP</c> (Garnet, for example) answer every read with it, so retrying at the poll interval
+    /// is pointless: the fetch loop drops to <see cref="MaxErrorBackoff"/> instead, which still recovers if the
+    /// connection later reaches a server that supports the command.
+    /// <para>
+    /// Matched as a case-insensitive substring rather than a prefix. Redis itself answers
+    /// <c>ERR unknown command 'X', with args beginning with:</c>, but the wording is a convention rather than a
+    /// contract: the <c>ERR</c> prefix can be rewritten by a proxy and managed services that disable a command
+    /// phrase it their own way. A server whose wording does not match here is not mishandled, it just falls to
+    /// the generic exponential backoff, which caps at the same <see cref="MaxErrorBackoff"/>; only the one-time
+    /// diagnostic naming the remedy is lost.
+    /// </para>
+    /// </summary>
+    internal const string UnknownCommandErrorMessage = "unknown command";
+
+    /// <summary>Upper bound for the exponential backoff applied after consecutive fetch failures.</summary>
+    internal static readonly TimeSpan MaxErrorBackoff = TimeSpan.FromSeconds(30);
+
+    /// <summary>Consecutive failures tolerated at the poll interval before backoff starts growing.</summary>
+    internal const int ErrorBackoffThreshold = 3;
 }

--- a/src/UiPath.Caching/Broadcast/TopicFactory.cs
+++ b/src/UiPath.Caching/Broadcast/TopicFactory.cs
@@ -20,7 +20,10 @@ public sealed class TopicFactory : ITopicFactory, IDisposable
         }
     }
 
-    public IEnumerable<string> ProviderNames => _providers.Values.Where(p => p.Enabled).Select(p => p.Name);
+    public IEnumerable<string> ProviderNames =>
+        _options.BroadcastEnabled
+            ? _providers.Values.Where(p => p.Enabled).Select(p => p.Name)
+            : [];
 
     public void AddProvider(ITopicProvider provider)
     {
@@ -34,8 +37,15 @@ public sealed class TopicFactory : ITopicFactory, IDisposable
         _disposed = true;
     }
 
+    /// <summary>
+    /// Resolves a topic provider by name. When <see cref="CacheOptions.BroadcastEnabled"/> is <c>false</c>
+    /// every resolution returns <see cref="NullTopicProvider"/>, so setting the flag at runtime silences
+    /// broadcast even for providers that were registered before it was read.
+    /// </summary>
     public ITopicProvider Get(string? providerName = null) =>
-        GetProvider(providerName ?? _options.DefaultTopic) ?? Default();
+        !_options.BroadcastEnabled
+            ? NullTopicProvider.Instance
+            : GetProvider(providerName ?? _options.DefaultTopic) ?? Default();
 
     private ITopicProvider Default() =>
         GetProvider(_options.DefaultTopic) ?? NullTopicProvider.Instance;

--- a/src/UiPath.Caching/InMemoryRedisCacheOptions.cs
+++ b/src/UiPath.Caching/InMemoryRedisCacheOptions.cs
@@ -22,6 +22,19 @@ public class InMemoryRedisCacheOptions : IMultilayerCacheOptions, IMemoryCacheOp
 
     public TimeSpan StatisticsFlushInterval { get; set; } = TimeSpan.FromMinutes(1);
 
+    /// <summary>
+    /// Publishes and consumes cross-node L1 invalidations for this provider. Set to <c>false</c> to run
+    /// L1+L2 with no broadcast traffic, which is what you want on a single node or against a Redis-compatible
+    /// store whose Streams support does not cover <c>XREADGROUP</c>. Defaults to <c>true</c>; note this is the
+    /// opposite of <see cref="InMemoryCacheOptions.BroadcastEnable"/>, which is opt-in.
+    /// <para>
+    /// This flag can only narrow the app-wide setting, never widen it. The effective behavior is
+    /// <see cref="CacheOptions.BroadcastEnabled"/> AND this property, so when broadcast is off app-wide
+    /// setting this to <c>true</c> has no effect.
+    /// </para>
+    /// </summary>
+    public bool BroadcastEnable { get; set; } = true;
+
     public string? Topic { get; set; }
 
     public ITopicKeyStrategy? TopicKeyStrategy { get; set; }

--- a/src/UiPath.Caching/InMemoryRedisCacheProvider.cs
+++ b/src/UiPath.Caching/InMemoryRedisCacheProvider.cs
@@ -43,9 +43,18 @@ public sealed class InMemoryRedisCacheProvider : ICacheProvider
         _cacheOptions = cacheOptionsAccessor.Value;
         _memoryCacheFactory = memoryCacheFactory;
         _cacheFactory = new Lazy<ICacheFactory>(cacheFactoryAccessor);
-        _changeTokenFactory = changeTokenFactory;
-        _topicFactory = topicFactory;
-        _cacheEventFactory = cacheEventFactory;
+        if (_options.BroadcastEnable)
+        {
+            _changeTokenFactory = changeTokenFactory;
+            _topicFactory = topicFactory;
+            _cacheEventFactory = cacheEventFactory;
+        }
+        else
+        {
+            _changeTokenFactory = NullChangeTokenFactory.Instance;
+            _topicFactory = NullTopicFactory.Instance;
+            _cacheEventFactory = NullCacheEventFactory.Instance;
+        }
         _cachingTelemetryProvider = cachingTelemetryProvider;
         _loggerFactory = loggerFactory;
         _localLock = localLock;

--- a/src/UiPath.Caching/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+UiPath.Caching.InMemoryRedisCacheOptions.BroadcastEnable.get -> bool
+UiPath.Caching.InMemoryRedisCacheOptions.BroadcastEnable.set -> void

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
@@ -259,6 +259,115 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
 
     private static readonly TimeSpan NogroupPollTimeout = TimeSpan.FromSeconds(30);
 
+    [Theory]
+    [InlineData("ERR unknown command 'XREADGROUP'")]
+    [InlineData("err unknown command 'xreadgroup', with args beginning with:")]
+    [InlineData("unknown command XREADGROUP")] // proxy stripped the ERR prefix
+    public async Task Unknown_command_is_logged_once_and_stops_hammering_the_server(string message)
+    {
+        // A RESP server without XREADGROUP (Garnet, for example) fails identically on every attempt. The loop
+        // must not re-issue it once per poll interval, and must not log the same critical error every time.
+        var recordingLogger = new RecordingLogger();
+        var loggedCritical = new TaskCompletionSource();
+        recordingLogger.OnRecord = r =>
+        {
+            if (r.Level == LogLevel.Critical)
+            {
+                loggedCritical.TrySetResult();
+            }
+        };
+        var attempts = 0;
+        _database.StreamReadGroupAsync(_context.Topic, _context.ConsumerGroup, _context.ConsumerName, ">", _context.PollBatchSize)
+            .ReturnsForAnyArgs<StreamEntry[]>(_ =>
+            {
+                Interlocked.Increment(ref attempts);
+                throw UnknownCommandError(message);
+            });
+
+        using var sut = CreateSut(Channel.CreateUnbounded<ICacheEvent>().Writer, recordingLogger);
+        await loggedCritical.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+        // The quarantine backoff is far longer than several poll intervals, so nothing more should happen.
+        await Task.Delay(_pollInterval.Multiply(10), TestContext.Current.CancellationToken);
+
+        recordingLogger.Records.Count(r => r.Level == LogLevel.Critical)
+            .Should().Be(1, "the unsupported-command error must be reported once, not once per poll interval");
+        Volatile.Read(ref attempts)
+            .Should().Be(1, "a command the server does not implement must not be re-issued every poll interval");
+
+        sut.FetchTask.IsCompleted.Should().BeFalse("the loop stays alive so a reconnect to a capable server can recover");
+
+        _cancellationTokenSource.Cancel();
+        try { await sut.FetchTask.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken); } catch (OperationCanceledException) { }
+    }
+
+    [Fact]
+    public async Task Unknown_command_quarantine_is_lifted_when_the_connection_reconnects()
+    {
+        var recordingLogger = new RecordingLogger();
+        var loggedCritical = new TaskCompletionSource();
+        recordingLogger.OnRecord = r =>
+        {
+            if (r.Level == LogLevel.Critical)
+            {
+                loggedCritical.TrySetResult();
+            }
+        };
+
+        var fail = true;
+        _database.StreamReadGroupAsync(_context.Topic, _context.ConsumerGroup, _context.ConsumerName, ">", _context.PollBatchSize)
+            .ReturnsForAnyArgs(_ => fail
+                ? throw UnknownCommandError("ERR unknown command 'XREADGROUP'")
+                : Task.FromResult(Array.Empty<StreamEntry>()));
+
+        var connectionState = _fixture.Create<IConnectionState>();
+        connectionState.IsConnected.Returns(true);
+        var redis = _fixture.Create<IRedisConnector>();
+        redis.Database.Returns(_database);
+
+        using var sut = new RedisStreamSubjectWriter<ICacheEvent>(
+            _context,
+            connectionState,
+            redis,
+            Channel.CreateUnbounded<ICacheEvent>().Writer,
+            _formatter,
+            recordingLogger,
+            _fixture.Create<ICachingTelemetryProvider>(),
+            _fixture.Create<IRedisProfiler>(),
+            new TimedFetchWaiter(_pollInterval),
+            _cancellationTokenSource.Token);
+
+        await loggedCritical.Task.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken);
+
+        // Server now answers XREADGROUP; the reconnect must wake the loop instead of waiting out the backoff.
+        fail = false;
+        connectionState.OnReconnected += Raise.Event<EventHandler>(connectionState, EventArgs.Empty);
+
+        var recovered = await WaitUntil(() => recordingLogger.Records.Any(
+            r => r.Level == LogLevel.Information && r.Message.Contains("recovered", StringComparison.OrdinalIgnoreCase)));
+
+        recovered.Should().BeTrue(
+            "the reconnect must wake the fetch loop so the next successful read lifts the quarantine, rather than leaving it to wait out the 30s backoff");
+
+        _cancellationTokenSource.Cancel();
+        try { await sut.FetchTask.WaitAsync(WaitTimeout, TestContext.Current.CancellationToken); } catch (OperationCanceledException) { }
+    }
+
+    private static async Task<bool> WaitUntil(Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + WaitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+        }
+
+        return false;
+    }
+
     [Fact]
     public async Task ProcessEvent_swallows_formatter_exception()
     {
@@ -485,4 +594,12 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         _fixture.Inject<IFetchWaiter>(new TimedFetchWaiter(_pollInterval));
         return ValueTask.CompletedTask;
     }
+
+    // RedisServerException(string) is obsolete as of StackExchange.Redis 3.1 and slated for removal in 3.2.
+    // Its replacement takes RedisErrorKind, which upstream still marks [Experimental] (SER007), so the
+    // suppression is centralized here rather than repeated at each call site.
+#pragma warning disable SER007 // RedisErrorKind is for evaluation purposes only
+    private static RedisServerException UnknownCommandError(string message) =>
+        new(RedisErrorKind.UnknownCommand, CommandFlags.None, message);
+#pragma warning restore SER007
 }

--- a/tests/UiPath.Caching.Tests/InMemoryRedisCacheProviderTests.cs
+++ b/tests/UiPath.Caching.Tests/InMemoryRedisCacheProviderTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Primitives;
 using UiPath.Caching;
 
 namespace UiPath.Caching.Tests;
@@ -19,6 +20,65 @@ public class InMemoryRedisCacheProviderTests : IAsyncLifetime
         Sut.Enabled.Should().Be(_options.Enabled);
     }
 
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Broadcast_option(bool enabled)
+    {
+        _options.BroadcastEnable = enabled;
+        var topicFactory = _fixture.Freeze<ITopicFactory>();
+        var topicProvider = _fixture.Freeze<ITopicProvider>();
+        topicFactory.Get(Arg.Any<string?>()).Returns(topicProvider);
+        var topic = _fixture.Create<ITopic<ICacheEvent>>();
+        topic.PublishAsync(Arg.Any<ICacheEvent>(), Arg.Any<CancellationToken>()).Returns(_ => true);
+        var topicCallsCount = 0;
+        topicProvider.Create(_fixture.Create<string>())
+            .ReturnsForAnyArgs(_ =>
+            {
+                topicCallsCount++;
+                return topic;
+            });
+
+        var changeTokenFactory = _fixture.Freeze<IChangeTokenFactory>();
+        var token = _fixture.Create<IChangeToken>();
+        var tokenCallsCount = 0;
+        changeTokenFactory.Create(Arg.Any<string>(), Arg.Any<ITopic<ICacheEvent>>(), Arg.Any<string>(), Arg.Any<Type>())
+            .ReturnsForAnyArgs(_ =>
+            {
+                tokenCallsCount++;
+                return token;
+            });
+
+        var cacheEventFactory = _fixture.Freeze<ICacheEventFactory>();
+        var cacheEvent = _fixture.Create<ICacheEvent>();
+        var eventCallsCount = 0;
+        cacheEventFactory.Create(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CacheEventData>(), Arg.Any<string>())
+            .ReturnsForAnyArgs(_ =>
+            {
+                eventCallsCount++;
+                return cacheEvent;
+            });
+
+        var cache = Sut.CreateCache();
+        var hashCache = Sut.CreateHashCache();
+        await cache.SetAsync(_fixture.Create<string>(), _fixture.Create<string>(), policy: null, token: TestContext.Current.CancellationToken);
+        var values = _fixture.Create<IDictionary<string, string?>>();
+        await hashCache.SetAsync(_fixture.Create<string>(), values, policy: null, token: TestContext.Current.CancellationToken);
+
+        if (enabled)
+        {
+            // The token and event counters also depend on the L1 write path, and the inner Redis cache is a
+            // substitute here, so topic resolution is the signal that the broadcast wiring is live.
+            topicCallsCount.Should().BeGreaterThan(0);
+        }
+        else
+        {
+            topicCallsCount.Should().Be(0, "BroadcastEnable: false must keep L1+L2 working without any broadcast traffic");
+            tokenCallsCount.Should().Be(0);
+            eventCallsCount.Should().Be(0);
+        }
+    }
 
     [Fact]
     public void Dispose_can_be_called()

--- a/tests/UiPath.Caching.Tests/TopicFactoryTests.cs
+++ b/tests/UiPath.Caching.Tests/TopicFactoryTests.cs
@@ -56,6 +56,29 @@ public class TopicFactoryTests : IAsyncLifetime
     }
 
     [Fact]
+    public void Broadcast_disabled_resolves_every_provider_to_null()
+    {
+        // CacheOptions.BroadcastEnabled used to be read only by RedisStreamHealthMaintainer, so setting it
+        // stopped the maintainer while the Streams fetch loop kept running. It has to gate topic resolution too.
+        _cacheOptions.BroadcastEnabled = false;
+
+        Sut.Get(_defaultProvider.Name).Should().BeOfType<NullTopicProvider>();
+        Sut.Get(null).Should().BeOfType<NullTopicProvider>();
+        Sut.ProviderNames.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Broadcast_disabled_wins_over_an_explicitly_enabled_provider()
+    {
+        _cacheOptions.BroadcastEnabled = false;
+        var provider = _fixture.Create<ITopicProvider>();
+        provider.Enabled.Returns(true);
+        Sut.AddProvider(provider);
+
+        Sut.Get(provider.Name).Should().BeOfType<NullTopicProvider>("the app-wide flag can only narrow, never be widened by a provider");
+    }
+
+    [Fact]
     public void Disposed_factory_add_provider_exception()
     {
         Sut.Dispose();


### PR DESCRIPTION
## Summary

Reported against Microsoft Garnet, a RESP-compatible store that implements Streams writes and ranges but not the consumer-group read side. Requesting the `InMemoryRedis` provider produced `ERR unknown command` from the fetch loop every 250 ms for the lifetime of the process, with no supported way to keep L1+L2 tiering while dropping the broadcast that caused it. Two of the three asks in the issue already worked (Pub/Sub as a transport, and `BroadcastEnabled: false` app-wide) but the report surfaced two genuine defects alongside the feature request.

## Changes

- **The fetch loop no longer re-issues a command the server does not implement.** It reports the case once at `Critical` with the available remedies, then retries at 30 s. A successful fetch lifts the quarantine and logs recovery, and a connection-restored/reconnected event wakes the loop early so recovery does not wait out the backoff. Recovery deliberately does not depend on that event: `CacheOptions.ConnectionMonitorEnabled` defaults to `false`, in which case the topic gets `NullConnectionStateMonitor`, where subscribing is a silent no-op and `IsConnected` is hardcoded `true`, so the timed retry is the guaranteed path. Other consecutive fetch failures now back off exponentially from `PollInterval` up to 30 s instead of retrying at the poll rate.
- **`CacheOptions.BroadcastEnabled` now actually disables broadcast.** It was read only by `RedisStreamHealthMaintainer`, so setting it through the `AddCaching` options lambda stopped the maintainer while the Streams fetch loop kept running, despite sharing a name with the configuration key that does perform the real opt-out. `TopicFactory` now resolves every topic to `NullTopicProvider` and reports no provider names when the flag is `false`.
- **New `InMemoryRedisCacheOptions.BroadcastEnable`** (default `true`) disables broadcast for that provider alone, mirroring what `InMemoryCacheProvider` already did for `InMemoryCacheOptions.BroadcastEnable`: the provider gets `NullTopicFactory` / `NullChangeTokenFactory` / `NullCacheEventFactory`. It can only narrow `CacheOptions.BroadcastEnabled`, never widen it. Its default is the opposite of the `InMemory` equivalent, which is opt-in, because `InMemoryRedis` has always broadcast by default; the asymmetry is called out in the XML doc, the settings table and the how-to rather than left implied.
- **Docs.** `concepts.md` now states that `AddInMemoryRedis()` wires broadcast internally and that a code-only `AddBroadcast(enabled: false)` does not stick, and links to `how-to/broadcast.md` — which already documented all of this but which the reporter never reached. The how-to gains a section on disabling broadcast for `InMemoryRedis` alone and a troubleshooting entry for `ERR unknown command` against Redis-compatible backends.

One public API addition (`InMemoryRedisCacheOptions.BroadcastEnable`), recorded in `PublicAPI.Unshipped.txt`. No breaking changes.

## Test plan

- [x] Unit tests added/updated
- [x] Integration tests pass locally (`dotnet test`)
- [x] CHANGELOG.md updated

New coverage: the unsupported-command path is logged once and issues exactly one command rather than one per poll interval (both casings), the quarantine is lifted when the connection reconnects, `TopicFactory` resolves to null when broadcast is off app-wide including over an explicitly enabled provider, and `InMemoryRedis` creates no topics when `BroadcastEnable` is `false`.

Full suite: 1227 passed, 0 failed, 5 skipped (the live-Redis integration tests, which need a running server).

## Linked issues

Fixes #103
