### PR TITLE
feat(cache): IDistributedCache adapter with case-sensitive keys and byte[] serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,6 @@ src/ProcessForms/UiPath.ProcessForms/UiPath.ProcessForms.XML
 
 # BenchmarkDotNet run output
 BenchmarkDotNet.Artifacts/
+
+# Local-only design notes (specs/plans); never committed
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,77 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+
+- **`IDistributedCache` adapter.** `builder.AddDistributedCache(providerName)` registers a
+  `Microsoft.Extensions.Caching.Distributed.IDistributedCache` backed by this library's pipeline —
+  shared Redis connection, resilience, telemetry — so consumers that require it (ASP.NET Core session
+  state, OpenIddict, DataProtection, rate limiters, and `HybridCache` as an L2) stop running a second,
+  parallel Redis stack. The backing tier is a required argument
+  (`Redis` recommended, `InMemoryRedis`, or `InMemory`); full absolute + sliding expiration and
+  `Refresh` semantics are supported. Keys are **always case-sensitive**, independent of
+  `CacheOptions.KeyCasing`, because `IDistributedCache` keys are opaque and case-significant.
+  Entries are stored as a Redis hash (`data`, `absexp`, `sldexp` — the conventional layout for this
+  contract) in a keyspace disjoint from the application's own caches, so `Refresh` reads
+  only the expiration metadata rather than transferring the payload. Keyspace separation is
+  configurable at both levels: `CacheKeyStrategy` prefixes the `CacheKey` itself (`d:` by default) so a
+  distributed entry cannot be reached through the application's own `ICache`/`IHashCache` with the bare
+  caller key, and `RedisKeyDifferentiator` plus `RedisKeyStrategyFactory` separate the physical Redis
+  keyspace (`dh` by default, inheriting the application's factory). A differentiator matching one of the
+  application's own type prefixes is rejected at registration, and because a differentiator only
+  separates anything if the factory honors it, registration also proves the composed key differs from
+  what the application's caches would produce. Configurable via
+  `UiPathDistributedCacheOptions`: `PolicyName`, `DefaultEntryExpiration`, and
+  `AllowUnboundedEntries`. Writes with no caller expiration take a bounded default rather than living
+  forever in shared storage; registration fails fast when no bounded default resolves and
+  `AllowUnboundedEntries` is not set.
+- **`CacheOptions.KeyCasing`** selects how keys built without an explicit mode are normalized —
+  `Insensitive` (trim + lowercase, the historical behavior and the default) or `Sensitive` (preserve
+  the caller's casing). `CacheKey` gained a `(string?, CacheKeyCasing)` constructor, a `Casing`
+  property, and `WithName` so key transformations preserve the mode. Changing the app-wide setting
+  relocates every cache key, so existing entries are rewritten under the new spelling.
+- **`CacheKeyComparer`** exposes cached `Sensitive` / `Insensitive` equality comparers over
+  `CacheKey`, in the `StringComparer` shape.
+- **`ISerializerProxy<byte[]>`** is a new serialization seam, defaulting to
+  `SystemJsonByteSerializerProxy`: byte payloads pass through raw (no base64, no JSON) and everything
+  else is UTF-8 JSON, with the requested type argument deciding. The existing
+  `ISerializerProxy<RedisValue>` registration and every existing wire format are untouched. Swapping
+  in a binary serializer such as MessagePack is one class and one registration — see
+  [how-to/extending.md](docs/how-to/extending.md).
+- **`RedisCacheOptions.AwaitRefresh`** (default `false`) waits for the server to apply a refresh instead of
+  sending `KEYEXPIRE`/`PERSIST` fire-and-forget. Off by default, which keeps the round trip off the
+  sliding-expiration path — it runs on every read of a sliding entry — and preserves existing behavior.
+  `AddDistributedCache` enables it on the private provider it builds, because a silently dropped refresh
+  shortens a session and fire-and-forget cannot report one. Honored by both `RedisCache` and
+  `RedisHashCache`.
+
 ### Changed
 
+- **BREAKING:** `CacheKey.Equals` and `GetHashCode` are now ordinal rather than
+  `InvariantCultureIgnoreCase`. Insensitive keys are still lowercased at construction, so the stored
+  key and every comparison between insensitive keys are unchanged; what changes is that equality is
+  now consistent with `GetHashCode` (the previous pairing could report two keys equal while hashing
+  them into different buckets) and that keys built with `CacheKeyCasing.Sensitive` compare
+  case-sensitively.
 - **`Microsoft.Extensions.*` dependency floor for `net10.0` raised to 10.0.11** (from 10.0.10).
   The `net8.0` floor is unchanged at 8.0.x.
 - **OpenTelemetry packages moved to 1.18.0** (`OpenTelemetry.Instrumentation.StackExchangeRedis` to 1.18.0-beta.1).
+
+### Fixed
+
+- **`RefreshAsync` on Redis reported nothing.** Both Redis caches sent their standalone
+  `KEYEXPIRE`/`PERSIST` fire-and-forget, so the call returned `false` whether the refresh succeeded, failed
+  or the key did not exist, the server's reply was never seen — a rejected command was neither logged nor
+  retried by the resilience pipeline — and telemetry recorded every refresh as unsuccessful. Setting
+  `RedisCacheOptions.AwaitRefresh` makes the result meaningful; the default is unchanged, so existing
+  callers see the previous behavior until they opt in. The fire-and-forget flags inside the write
+  transactions are untouched: those replies are discarded, but the transaction itself is awaited.
+- **`AddCaching(IConfigurationSection)` never bound `CacheOptions`.** The overload passed its options
+  binder positionally, so it landed on the `configure` parameter and type-checked as
+  `Action<ICachingBuilder>` — leaving `configureOptions` null, the section unread, and the config bound
+  onto the builder object instead. Every `CacheOptions` value supplied through that entry point was
+  silently ignored; `Enabled`, `AppShortName`, `KeyCasing` and the rest now take effect, which changes
+  behavior for anyone who was unknowingly running on the defaults.
 
 ## [1.3.0] - 2026-08-19
 

--- a/docs/how-to/extending.md
+++ b/docs/how-to/extending.md
@@ -286,6 +286,106 @@ That single registration replaces the default JSON serializer for every cache th
 - **Schema evolution is your problem.** The library does not version cached payloads. If your serializer can't deserialize an older payload after a deploy, `TryDeserialize` should return `false` and the cache will treat that as a miss; the generator will run and write a fresh entry.
 - **Consider `RedisValue` directly.** `RedisValue` can hold strings, bytes, or numbers without conversion. A binary serializer (MessagePack, ProtoBuf, MemoryPack) should write `byte[]` directly via `RedisValue` implicit conversion rather than going through `string`/Base64 — JSON-style proxies can stay string-based.
 
+### Byte-oriented serializers (`ISerializerProxy<byte[]>`)
+
+The distributed cache path (`AddDistributedCache`) serializes through `ISerializerProxy<byte[]>`
+instead of `ISerializerProxy<RedisValue>`. The default, `SystemJsonByteSerializerProxy`, passes
+`byte[]` payloads through raw — no base64, no JSON, no extra encoding layer — and JSON-encodes
+every other type; the requested type argument decides, there is no format sniffing.
+
+The distributed cache stores each entry as a Redis hash with a `data` field plus `absexp`/`sldexp`
+expiration metadata, the conventional layout for this contract, so
+`Refresh` reads the metadata without transferring the payload. Its keyspace is deliberately disjoint
+from the application's own caches, at two overridable levels — `RedisKeyDifferentiator` for the
+physical Redis keyspace, and `CacheKeyStrategy` for the `CacheKey` itself, so an entry cannot be
+reached through the application's own `ICache`/`IHashCache` with the bare caller key:
+
+```csharp
+builder.AddDistributedCache(KnownCacheProviderNames.Redis, o =>
+{
+    o.CacheKeyStrategy = new PrefixCacheKeyStrategy("sessions");
+    o.RedisKeyDifferentiator = "sess";
+});
+```
+
+Both default to values that keep the two keyspaces apart (`"d"` and `"dh"`); overriding them makes
+that separation yours to preserve. A differentiator matching one of the application's own
+`RedisTypePrefixes` is rejected at registration.
+
+For full control of the Redis key — a mandated layout, or a cluster hash-tag scheme —
+`RedisKeyStrategyFactory` replaces the factory the key is built from. It still receives
+`RedisKeyDifferentiator`, and registration proves the composed key differs from what the
+application's caches would produce, so a factory that ignores the differentiator fails at startup
+rather than sharing the keyspace:
+
+```csharp
+o.RedisKeyStrategyFactory = new MyRedisKeyStrategyFactory();   // gets "dh" (or your differentiator)
+```
+
+Left null it inherits the application's own `RedisCacheOptions.RedisKeyStrategyFactory`, so
+`AppShortName`, the separator and sharding behave as they do everywhere else.
+
+Swapping it follows the same pattern as the `RedisValue` proxy — and is simpler, because most
+binary serializers natively produce `byte[]`:
+
+```csharp
+public sealed class MessagePackByteSerializerProxy(MessagePackSerializerOptions? options = null)
+    : ISerializerProxy<byte[]>
+{
+    public byte[]? Serialize(object? value) =>
+        value is null ? null : MessagePackSerializer.Serialize(value.GetType(), value, options);
+
+    public T? Deserialize<T>(byte[]? value) =>
+        value is null or { Length: 0 } ? default : MessagePackSerializer.Deserialize<T>(value, options);
+
+    public bool TryDeserialize<T>(string? value, out T? result)
+    {
+        result = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+        try
+        {
+            result = MessagePackSerializer.Deserialize<T>(Convert.FromBase64String(value), options);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public bool TryDeserialize<T>(object? value, out T? result)
+    {
+        result = default;
+        try
+        {
+            if (value is byte[] bytes)
+            {
+                result = MessagePackSerializer.Deserialize<T>(bytes, options);
+                return true;
+            }
+            return TryDeserialize(value?.ToString(), out result);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}
+
+services.AddSingleton<ISerializerProxy<byte[]>>(new MessagePackByteSerializerProxy());
+```
+
+Two rules for custom implementations:
+
+1. **Round-trip `byte[]` symmetrically.** The distributed cache stores the caller's payload directly
+   in the hash's `data` field; raw passthrough (recommended) avoids per-entry encoding overhead, but
+   any symmetric encoding also works.
+2. **This does not change the main caches' wire format** — `ICache`/`IHashCache` still serialize
+   through `ISerializerProxy<RedisValue>`. Swap both registrations if you want one format everywhere.
+
 ## Swapping the default factories
 
 `ICacheFactory` and `ICachePolicyFactory` each have a default DI registration set up by `AddCaching` — the concrete `CacheFactory` and `DefaultCachePolicyFactory` respectively. When you need to substitute either, use the fluent `Use*Factory` extensions on `ICachingBuilder`. They internally call `Services.Replace(...)` so the swap survives the rest of the `AddCaching` pipeline (which uses `TryAddSingleton` and would otherwise lose to the default registration).

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -27,6 +27,7 @@ Every binding-visible property on every shipped options class, with shipped defa
 | `SourceUri` | `Uri?` | `urn:<hostname>` | App-wide | Machine/pod identity embedded in cross-node sync events; use _placeholder_ `"urn:machine1"` in config, override per environment. |
 | `Separator` | `char` | `':'` | App-wide | Character used to join cache key segments. |
 | `AppShortName` | `string` | _required_ | App-wide | Short application name prefixed to every cache key; apps throw at startup if blank or missing. |
+| `KeyCasing` | `CacheKeyCasing` | `Insensitive` | App-wide | Key case folding applied when a key is built without an explicit mode, including every implicit `string` -> `CacheKey` conversion. `Insensitive` trims and lowercases (historical behavior); `Sensitive` preserves the caller's casing. **Changing this relocates every cache key** — existing entries become unreachable and are rewritten under the new spelling. The distributed cache always uses `Sensitive` and is unaffected. Scope is the **process**, not the container: `CacheKey` is a struct built by callers without access to DI, so the setting is seeded into the static `CacheKey.DefaultCasing`. Hosting two differently-configured containers in one process is therefore unsupported — the last `AddCaching` wins for both. |
 | `LargeValueThreshold` | `int` | `20000` | App-wide | Byte threshold for audit logging; writes whose payload exceeds this are logged when `AuditEnabled` is `true`. |
 | `ConnectionMonitorEnabled` | `bool` | `false` | App-wide | Enable Redis health-check polling app-wide; provider-level `ConnectionMonitorEnabled` inherits this when `null`. |
 | `LocalLockPoolSize` | `int` | `100` | App-wide | Semaphore pool size for the default local lock — allocation hint, not a hard concurrency cap. |
@@ -173,6 +174,7 @@ Per-topic overrides: add entries to `Topics[]` under `Broadcast:RedisPubSub`. Ea
 | `ConnectionMonitorEnabled` | `bool?` | `null` | Per-provider | `null` = inherit from `CacheOptions.ConnectionMonitorEnabled`. |
 | `CacheNullValues` | `bool` | `false` | Per-provider | Persist `null`/empty factory returns as sentinels to suppress thundering-herd on missing keys. |
 | `KeyReadTelemetryEnabled` | `bool` | `false` | Per-provider | Opt-in per-key read attribution: each read emits a `Redis` dependency carrying the key in `data` (one per hash key for hash reads), with a `BatchId` shared across the operation. Off by default because raw keys are high-cardinality; the per-operation hit/miss metric is always emitted regardless. |
+| `AwaitRefresh` | `bool` | `false` | Per-provider | Wait for the server to apply a refresh instead of sending `KEYEXPIRE`/`PERSIST` fire-and-forget. Off by default, keeping the round trip off the sliding-expiration path, which runs on every read of a sliding entry. While off, a refresh is unverifiable: `RefreshAsync` returns `false` whether it succeeded, failed or the key was absent; the reply is never seen, so a rejected command is neither logged nor retried by the resilience pipeline, and telemetry records every refresh as unsuccessful; and the new deadline is not yet in effect when the call returns. Turn it on where a lost refresh matters more than a round trip. `AddDistributedCache` sets it for its own provider. |
 
 *Code-only seams:* `Clock`, `EntryFactory`, `CacheKeyStrategy`, `RedisKeyStrategyFactory`.
 
@@ -204,6 +206,75 @@ Per-topic overrides: add entries to `Topics[]` under `Broadcast:RedisPubSub`. Ea
 | `DistributedLockExpiry` | `TimeSpan?` | `null` | Per-provider | Inert for this provider; present to satisfy `IMultilayerCacheOptions`. |
 
 *Code-only seams:* `Clock`, `EntryFactory`, `CacheKeyStrategy`, `TopicKeyStrategy`, `SizeProvider`, `LockKeyStrategy`.
+
+---
+
+## Caching:Distributed (UiPathDistributedCacheOptions)
+
+Registered in code via `builder.AddDistributedCache(providerName)`; the backing tier is a required
+argument (`Redis` recommended, `InMemoryRedis`, or `InMemory`). The options object is passed to the
+extension rather than bound from configuration.
+
+| Property | Type | Default | Scope | Notes |
+|---|---|---|---|---|
+| `CacheKeyStrategy` | `ICacheKeyStrategy?` | `null` | Per registration | Composes the stored key from the caller key. Null applies `PrefixCacheKeyStrategy` with `DefaultKeyPrefix` (`"d"`); pass `new PrefixCacheKeyStrategy("d:sess")` to sub-namespace while keeping that prefix, or `DefaultCacheKeyStrategy` to opt out of prefixing entirely. Code-only seam. |
+| `RedisKeyDifferentiator` | `string?` | `null` | Per registration | Fills the slot after `AppShortName` that the application's caches fill with a `RedisTypePrefixes` value. Null uses `DefaultRedisKeyDifferentiator` (`"dh"`). Inert on the `InMemory` tier; a value matching a `RedisTypePrefixes` value is rejected at registration. Prefixes belonging to packages layered on top of `UiPath.Caching` are **not** checked — it cannot see them without depending on them — so avoid those too: `UiPath.Caching.Queue`'s set cache uses `"se"`. |
+| `RedisKeyStrategyFactory` | `IRedisKeyStrategyFactory?` | `null` | Per registration | Builds the Redis key, receiving `RedisKeyDifferentiator`. Null inherits the application's `RedisCacheOptions.RedisKeyStrategyFactory`, keeping its `AppShortName`, separator and sharding conventions. Code-only seam. |
+| `PolicyName` | `string?` | `null` | Per registration | Named `CachePolicy` applied to the adapter's operations; an unregistered name fails fast at startup. |
+| `DefaultEntryExpiration` | `TimeSpan?` | `null` | Per registration | Expiration used when the caller supplies none. `IDistributedCache` treats absent expiration as "until removed"; unless `AllowUnboundedEntries` is set that is mapped to this value, falling back to the backing tier's `DefaultExpiration`. |
+| `AllowUnboundedEntries` | `bool` | `false` | Per registration | Honor "no expiration" literally. Off by default: registration fails when no bounded default can be resolved, so shared storage cannot accumulate keys that never expire. |
+
+Entries are stored as a Redis hash (`data`, `absexp`, `sldexp`) in a keyspace disjoint from the
+application's own caches, so `Refresh` reads only the expiration metadata. Keys are always
+case-sensitive regardless of `CacheOptions.KeyCasing`.
+
+**Keyspace separation.** A full Redis key carries three independent segments, each answering a
+different question:
+
+```
+app  :  dh  :  d:  <caller key>
+└─┬─┘   └┬─┘   └┬┘
+  │      │      └─ CacheKey level: CacheKeyStrategy ("d:" by default)
+  │      └─ RedisKeyDifferentiator — separates this cache from the application's own
+  └─ CacheOptions.AppShortName — separates applications sharing one Redis
+```
+
+`AppShortName` is required and app-wide, so it is never this registration's job. `CacheKeyStrategy`
+prefixes the `CacheKey` itself, so a distributed entry cannot be reached through the application's own
+`ICache`/`IHashCache` with the bare caller key, and the memory tiers' local lock keyspace (keyed by
+provider name plus cache key) stays separate too — neither of which a Redis-key-level segment can do.
+`RedisKeyDifferentiator` and `RedisKeyStrategyFactory` separate the physical Redis keyspace, taking the
+slot the application's caches fill with a `RedisTypePrefixes` value. Because a differentiator only separates anything if the factory
+honors it, registration composes a probe key both ways and fails when the distributed key matches what
+the application's own caches would produce — so a factory that ignores its differentiator argument is
+rejected instead of quietly sharing the keyspace.
+
+The cache-key strategy is applied by the adapter rather than by the backing provider's own
+`ICacheOptions.CacheKeyStrategy`, which `RedisHashCache` does not consult — routing it through the
+provider would make the stored key depend on which tier is configured.
+
+> **Keys appear in logs.** `IDistributedCache` keys are chosen by the consumer and can be secrets — under
+> ASP.NET Core session the key is the session id. This adapter names the key in its two own messages (a failed
+> write at `Warning`, a no-op remove at `Debug`), and the composed key is passed to the backing cache, which
+> logs it in its own diagnostics too: `MultilayerHashCache` includes the `CacheKey` in five `LogLevel.Warning` messages (raised on
+> inner-cache exceptions) and in several Debug/Trace ones, and `RedisHashCache` includes the physical key in
+> `LogLargeValueDetected` (Warning) and `LogRefreshingKey` (Trace). Keys stored verbatim for parity with
+> the conventional layout also means they appear in `KEYS`/`SCAN` output and RDB
+> snapshots. Treat logs and Redis dumps for this provider as containing session identifiers, or filter the
+> `UiPath.Caching` log categories accordingly.
+
+**`Refresh` waits for the server on this provider.** `AddDistributedCache` sets
+`RedisCacheOptions.AwaitRefresh` on the private provider it builds, so `IDistributedCache.Refresh` — and the
+sliding extension a `Get` performs — costs a round trip but is in effect when the call returns, a rejection
+reaches the log and the resilience pipeline, and telemetry reflects the real outcome. Deliberate for a
+session store: a silently dropped refresh shortens the session and fire-and-forget cannot report one. The
+application's own caches keep the fire-and-forget default; see `AwaitRefresh` above.
+
+**Backing-tier caveats.** `InMemoryRedis` carries a stale-read window until backplane invalidation
+lands and requires `AddInMemoryRedis` for its broadcast wiring (enforced at startup). `InMemory`
+stores entries only in memory, where `InMemoryCacheOptions.LocalMaxExpiration` (1 hour by default)
+caps every entry regardless of the caller's requested expiration — use it for tests and single-node
+scenarios, not for long-lived entries.
 
 ---
 

--- a/src/UiPath.Caching.Abstractions/CacheKey.cs
+++ b/src/UiPath.Caching.Abstractions/CacheKey.cs
@@ -4,21 +4,60 @@ namespace UiPath.Caching;
 
 public readonly struct CacheKey : IEquatable<CacheKey>
 {
+    private static CacheKeyCasing _defaultCasing = CacheKeyCasing.Insensitive;
+
+    /// <summary>
+    /// Process-global casing for keys built without an explicit mode; seeded from <c>CacheOptions.KeyCasing</c>.
+    /// Set only at startup. Rejects a value outside the enum on assignment rather than at the next key built,
+    /// since this is global state and the throw would otherwise surface far from the assignment that caused it.
+    /// </summary>
+    public static CacheKeyCasing DefaultCasing
+    {
+        get => _defaultCasing;
+        set => _defaultCasing = value is CacheKeyCasing.Insensitive or CacheKeyCasing.Sensitive
+            ? value
+            : throw new ArgumentOutOfRangeException(nameof(value), value, $"Unsupported {nameof(CacheKeyCasing)} value.");
+    }
+
     public CacheKey()
     : this(string.Empty)
     {
     }
 
-    public CacheKey(string? name) =>
-        Name = name?.Trim().ToLowerInvariant() ?? string.Empty;
+    public CacheKey(string? name)
+    : this(name, DefaultCasing)
+    {
+    }
+
+    /// <summary>
+    /// Builds a key, trimming the name and lowercasing it when <paramref name="casing"/> is
+    /// <see cref="CacheKeyCasing.Insensitive"/>. An unrecognized value is rejected rather than treated as
+    /// sensitive, which would silently stop lowercasing and relocate every key built with it.
+    /// </summary>
+    public CacheKey(string? name, CacheKeyCasing casing)
+    {
+        Casing = casing;
+        Name = casing switch
+        {
+            CacheKeyCasing.Insensitive => name?.Trim().ToLowerInvariant() ?? string.Empty,
+            CacheKeyCasing.Sensitive => name?.Trim() ?? string.Empty,
+            _ => throw new ArgumentOutOfRangeException(nameof(casing), casing, $"Unsupported {nameof(CacheKeyCasing)} value."),
+        };
+    }
 
     public string Name { get; }
+
+    /// <summary>Normalization mode this key was built with; not part of equality.</summary>
+    public CacheKeyCasing Casing { get; }
+
+    /// <summary>New key from <paramref name="name"/>, preserving this key's casing mode.</summary>
+    public CacheKey WithName(string? name) => new(name, Casing);
 
     public override bool Equals(object? obj) =>
         obj is CacheKey cacheKey && Equals(cacheKey);
 
     public bool Equals(CacheKey other) =>
-        string.Equals(Name, other.Name, StringComparison.InvariantCultureIgnoreCase);
+        string.Equals(Name, other.Name, StringComparison.Ordinal);
 
     public bool IsNull => string.IsNullOrEmpty(Name);
 

--- a/src/UiPath.Caching.Abstractions/CacheKeyCasing.cs
+++ b/src/UiPath.Caching.Abstractions/CacheKeyCasing.cs
@@ -1,0 +1,11 @@
+namespace UiPath.Caching;
+
+/// <summary>How <see cref="CacheKey"/> normalizes its name at construction; comparison is always ordinal.</summary>
+public enum CacheKeyCasing
+{
+    /// <summary>Trim and lowercase (invariant). The historical default.</summary>
+    Insensitive = 0,
+
+    /// <summary>Trim only; the caller's casing is preserved.</summary>
+    Sensitive = 1,
+}

--- a/src/UiPath.Caching.Abstractions/CacheKeyComparer.cs
+++ b/src/UiPath.Caching.Abstractions/CacheKeyComparer.cs
@@ -1,0 +1,25 @@
+namespace UiPath.Caching;
+
+/// <summary>Cached <see cref="CacheKey"/> equality comparers: <see cref="Sensitive"/> (ordinal, the struct's own equality) and <see cref="Insensitive"/> (ordinal, case-folding).</summary>
+public abstract class CacheKeyComparer : EqualityComparer<CacheKey>
+{
+    public static CacheKeyComparer Sensitive { get; } = new SensitiveComparer();
+
+    public static CacheKeyComparer Insensitive { get; } = new InsensitiveComparer();
+
+    private sealed class SensitiveComparer : CacheKeyComparer
+    {
+        public override bool Equals(CacheKey x, CacheKey y) => x.Equals(y);
+
+        public override int GetHashCode(CacheKey obj) => obj.GetHashCode();
+    }
+
+    private sealed class InsensitiveComparer : CacheKeyComparer
+    {
+        public override bool Equals(CacheKey x, CacheKey y) =>
+            string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+
+        public override int GetHashCode(CacheKey obj) =>
+            obj.Name is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name);
+    }
+}

--- a/src/UiPath.Caching.Abstractions/CacheOptions.cs
+++ b/src/UiPath.Caching.Abstractions/CacheOptions.cs
@@ -18,6 +18,9 @@ public class CacheOptions
 
     public bool AuditEnabled { get; set; } = true;
 
+    /// <summary>Seeds <see cref="CacheKey.DefaultCasing"/> when options bind. The distributed cache ignores this — its keys are always sensitive.</summary>
+    public CacheKeyCasing KeyCasing { get; set; } = CacheKeyCasing.Insensitive;
+
     public string DefaultCache { get; set; } = KnownCacheProviderNames.InMemoryRedis;
 
     public string DefaultTopic { get; set; } = KnownTopicNames.RedisStreams;

--- a/src/UiPath.Caching.Abstractions/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching.Abstractions/PublicAPI.Unshipped.txt
@@ -1,1 +1,21 @@
 #nullable enable
+UiPath.Caching.CacheKey.CacheKey(string? name, UiPath.Caching.CacheKeyCasing casing) -> void
+UiPath.Caching.CacheKey.Casing.get -> UiPath.Caching.CacheKeyCasing
+UiPath.Caching.CacheKey.WithName(string? name) -> UiPath.Caching.CacheKey
+UiPath.Caching.CacheKeyCasing
+UiPath.Caching.CacheKeyCasing.Insensitive = 0 -> UiPath.Caching.CacheKeyCasing
+UiPath.Caching.CacheKeyComparer
+UiPath.Caching.CacheKeyComparer.CacheKeyComparer() -> void
+static UiPath.Caching.CacheKeyComparer.Insensitive.get -> UiPath.Caching.CacheKeyComparer!
+static UiPath.Caching.CacheKeyComparer.Sensitive.get -> UiPath.Caching.CacheKeyComparer!
+UiPath.Caching.CacheKeyCasing.Sensitive = 1 -> UiPath.Caching.CacheKeyCasing
+UiPath.Caching.CacheOptions.KeyCasing.get -> UiPath.Caching.CacheKeyCasing
+UiPath.Caching.CacheOptions.KeyCasing.set -> void
+UiPath.Caching.SystemJsonByteSerializerProxy
+UiPath.Caching.SystemJsonByteSerializerProxy.SystemJsonByteSerializerProxy(System.Text.Json.JsonSerializerOptions? options = null) -> void
+UiPath.Caching.SystemJsonByteSerializerProxy.Serialize(object? value) -> byte[]?
+UiPath.Caching.SystemJsonByteSerializerProxy.Deserialize<T>(byte[]? value) -> T?
+UiPath.Caching.SystemJsonByteSerializerProxy.TryDeserialize<T>(string? value, out T? result) -> bool
+UiPath.Caching.SystemJsonByteSerializerProxy.TryDeserialize<T>(object? value, out T? result) -> bool
+static UiPath.Caching.CacheKey.DefaultCasing.get -> UiPath.Caching.CacheKeyCasing
+static UiPath.Caching.CacheKey.DefaultCasing.set -> void

--- a/src/UiPath.Caching.Abstractions/SystemJsonByteSerializerProxy.cs
+++ b/src/UiPath.Caching.Abstractions/SystemJsonByteSerializerProxy.cs
@@ -1,0 +1,91 @@
+using System.Text.Json;
+
+namespace UiPath.Caching;
+
+/// <summary>JSON serializer over <c>byte[]</c>: byte payloads pass through raw, everything else is UTF-8 JSON; the type argument decides, no format sniffing.</summary>
+public class SystemJsonByteSerializerProxy(JsonSerializerOptions? options = null) : ISerializerProxy<byte[]>
+{
+    public byte[]? Serialize(object? value) => value switch
+    {
+        null => null,
+        byte[] bytes => bytes,
+        ReadOnlyMemory<byte> memory => memory.ToArray(),
+        Memory<byte> memory => memory.ToArray(),
+        _ => JsonSerializer.SerializeToUtf8Bytes(value, options),
+    };
+
+    public T? Deserialize<T>(byte[]? value)
+    {
+        if (value is null)
+        {
+            return default;
+        }
+        if (typeof(T) == typeof(byte[]))
+        {
+            return (T)(object)value;
+        }
+        if (typeof(T) == typeof(ReadOnlyMemory<byte>))
+        {
+            return (T)(object)new ReadOnlyMemory<byte>(value);
+        }
+        if (typeof(T) == typeof(Memory<byte>))
+        {
+            return (T)(object)new Memory<byte>(value);
+        }
+        if (value.Length == 0)
+        {
+            return default;
+        }
+        return JsonSerializer.Deserialize<T>(value, options);
+    }
+
+    public bool TryDeserialize<T>(string? value, out T? result)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            result = default;
+            return false;
+        }
+        try
+        {
+            result = JsonSerializer.Deserialize<T>(value, options);
+            return true;
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+    }
+
+    public bool TryDeserialize<T>(object? value, out T? result)
+    {
+        if (value == null)
+        {
+            result = default;
+            return false;
+        }
+        try
+        {
+            switch (value)
+            {
+                case byte[] { Length: 0 }:
+                    result = default;
+                    return false;
+                case byte[] bytes:
+                    result = Deserialize<T>(bytes);
+                    return true;
+                case JsonElement jsonElement:
+                    result = jsonElement.Deserialize<T>(options);
+                    return true;
+                default:
+                    return TryDeserialize(value.ToString() ?? string.Empty, out result);
+            }
+        }
+        catch
+        {
+            result = default;
+            return false;
+        }
+    }
+}

--- a/src/UiPath.Caching/Config/CacheKeyCasingSeeder.cs
+++ b/src/UiPath.Caching/Config/CacheKeyCasingSeeder.cs
@@ -1,0 +1,28 @@
+namespace UiPath.Caching.Config;
+
+/// <summary>
+/// Validates <see cref="CacheOptions.KeyCasing"/> and seeds <see cref="CacheKey.DefaultCasing"/> from it.
+/// Runs as options validation rather than a PostConfigure callback so it observes the final value: callbacks
+/// run in registration order, so a consumer post-configuring <c>KeyCasing</c> after <c>AddCaching</c> would
+/// change the resolved options while leaving the process-global default at whatever was seeded first —
+/// <c>new CacheKey("AbC")</c> lowercasing while <c>IOptions&lt;CacheOptions&gt;.Value</c> reported otherwise.
+/// </summary>
+internal sealed class CacheKeyCasingSeeder : IValidateOptions<CacheOptions>
+{
+    public ValidateOptionsResult Validate(string? name, CacheOptions options)
+    {
+        if (name is not null && name != Options.DefaultName)
+        {
+            return ValidateOptionsResult.Skip;
+        }
+
+        if (options.KeyCasing is not (CacheKeyCasing.Insensitive or CacheKeyCasing.Sensitive))
+        {
+            return ValidateOptionsResult.Fail(
+                $"CacheOptions.KeyCasing has the unsupported value {(int)options.KeyCasing}. Use {nameof(CacheKeyCasing.Insensitive)} or {nameof(CacheKeyCasing.Sensitive)}.");
+        }
+
+        CacheKey.DefaultCasing = options.KeyCasing;
+        return ValidateOptionsResult.Success;
+    }
+}

--- a/src/UiPath.Caching/Config/CachingBuilder.cs
+++ b/src/UiPath.Caching/Config/CachingBuilder.cs
@@ -29,7 +29,10 @@ public class CachingBuilder(IServiceCollection services, IConfiguration? configu
             callback(this);
         }
 
+        Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<CacheOptions>, CacheKeyCasingSeeder>());
         Services.TryAddSingleton<ISerializerProxy<RedisValue>>(sp => new SystemJsonSerializerProxy(sp.GetService<JsonSerializerOptions>()));
+        Services.TryAddSingleton<ISerializerProxy<byte[]>>(sp => new SystemJsonByteSerializerProxy(sp.GetService<JsonSerializerOptions>()));
         Services.TryAddSingleton<IResiliencePipelineProvider>(EmptyResiliencePipelineProvider.Instance);
         Services.TryAddSingleton<IChangeTokenFactory>(NullChangeTokenFactory.Instance);
         Services.TryAddSingleton<ITopicFactory>(NullTopicFactory.Instance);

--- a/src/UiPath.Caching/Config/DistributedCacheCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/DistributedCacheCollectionExtensions.cs
@@ -1,0 +1,435 @@
+using Microsoft.Extensions.Caching.Distributed;
+using UiPath.Caching.Distributed;
+using UiPath.Caching.Locking;
+using UiPath.Caching.Policies;
+using UiPath.Caching.Telemetry;
+
+namespace UiPath.Caching.Config;
+
+public static class DistributedCacheCollectionExtensions
+{
+    /// <summary>Service key of the distributed cache's private <see cref="ICacheProvider"/> and <see cref="IHashCache"/> registrations.</summary>
+    public const string DistributedCacheServiceKey = "UiPath.Caching.Distributed";
+
+    /// <summary>
+    /// The application's own caches fill the differentiator slot with a <see cref="RedisTypePrefixes"/>
+    /// value, so a distributed differentiator matching one of them would merge the two keyspaces. Only this
+    /// assembly's prefixes are listed: a package layered on top of it defines its own, which this assembly
+    /// cannot see without depending on it the wrong way round.
+    /// </summary>
+    private static readonly string[] ApplicationTypePrefixes =
+    [
+        RedisTypePrefixes.String,
+        RedisTypePrefixes.Hash,
+        RedisTypePrefixes.PubSub,
+        RedisTypePrefixes.Streams,
+    ];
+
+    /// <summary>Registers an <see cref="IDistributedCache"/> backed by a dedicated case-sensitive cache instance in its own keyspace. <paramref name="providerName"/> selects the backing tier: Redis (recommended), InMemoryRedis, or InMemory.</summary>
+    public static ICachingBuilder AddDistributedCache(
+        this ICachingBuilder builder,
+        string providerName,
+        Action<UiPathDistributedCacheOptions>? configure = null)
+    {
+        Guard.NotNullOrWhiteSpace(providerName, nameof(providerName));
+        var options = new UiPathDistributedCacheOptions();
+        configure?.Invoke(options);
+        EnsureKeyspaceIsolation(options);
+
+        if (builder.Services.Any(d => d.IsKeyedService
+            && Equals(d.ServiceKey, DistributedCacheServiceKey)
+            && d.ServiceType == typeof(IHashCache)))
+        {
+            throw new InvalidOperationException(
+                "AddDistributedCache has already been called. Registering it twice would build the adapter from the first call's options over the second call's backing tier; call it once.");
+        }
+
+        if (!builder.Enabled)
+        {
+            RegisterNullAdapter(builder);
+            return builder;
+        }
+
+        if (providerName is KnownCacheProviderNames.InMemory or KnownCacheProviderNames.InMemoryRedis)
+        {
+            builder.Services.TryAddMemoryCacheFactory();
+        }
+
+        builder.Services.AddKeyedSingleton<ICacheProvider>(DistributedCacheServiceKey,
+            (sp, _) => CreateProvider(sp, providerName, options));
+        builder.Services.AddKeyedSingleton<IHashCache>(DistributedCacheServiceKey,
+            (sp, key) => CreateHashCache(sp, key!, providerName));
+
+        RegisterAdapter(builder.Services, ServiceDescriptor.Singleton<IDistributedCache>(sp => new UiPathDistributedCache(
+            sp.GetRequiredKeyedService<IHashCache>(DistributedCacheServiceKey),
+            options,
+            ResolveCacheKeyStrategy(options),
+            ResolvePolicy(sp, options),
+            sp.GetRequiredService<ILoggerFactory>().Create<UiPathDistributedCache>(),
+            sp.GetService<ISystemClock>(),
+            slideByRewrite: providerName == KnownCacheProviderNames.InMemory)));
+
+        return builder;
+    }
+
+    /// <summary>Satisfies <see cref="IDistributedCache"/> when caching is switched off, so <c>AddSession()</c> and DataProtection resolve instead of failing at startup.</summary>
+    private static void RegisterNullAdapter(ICachingBuilder builder) =>
+        builder.Services.Replace(ServiceDescriptor.Singleton<IDistributedCache>(NullDistributedCache.Instance));
+
+    /// <summary>Replace rather than TryAdd, so a host that called <c>AddDistributedMemoryCache()</c> first cannot silently win and turn this registration into a no-op.</summary>
+    private static void RegisterAdapter(IServiceCollection services, ServiceDescriptor adapter) =>
+        services.Replace(adapter);
+
+    /// <summary>
+    /// Honors the tier's own <c>Enabled</c> switch the way <see cref="CacheFactory"/> does. The switch is read
+    /// from the tier's options before the provider is resolved, so a disabled tier yields a null cache instead
+    /// of first demanding the infrastructure that provider would need.
+    /// </summary>
+    private static IHashCache CreateHashCache(IServiceProvider sp, object serviceKey, string providerName)
+    {
+        if (!IsTierEnabled(sp, providerName))
+        {
+            return NullHashCache.Instance;
+        }
+
+        var provider = sp.GetRequiredKeyedService<ICacheProvider>(serviceKey);
+        return provider.Enabled ? provider.CreateHashCache() : NullHashCache.Instance;
+    }
+
+    /// <summary>An unrecognized name resolves the provider anyway, so the unsupported-tier error still surfaces.</summary>
+    private static bool IsTierEnabled(IServiceProvider sp, string providerName) =>
+        providerName switch
+        {
+            KnownCacheProviderNames.Redis => sp.GetRequiredService<IOptions<RedisCacheOptions>>().Value.Enabled,
+            KnownCacheProviderNames.InMemoryRedis => sp.GetRequiredService<IOptions<InMemoryRedisCacheOptions>>().Value.Enabled,
+            KnownCacheProviderNames.InMemory => sp.GetRequiredService<IOptions<InMemoryCacheOptions>>().Value.Enabled,
+            _ => true,
+        };
+
+    /// <summary>
+    /// The multilayer tier keeps entries in a local layer that only broadcast invalidates across nodes, so
+    /// without effective broadcast a node serves stale sessions indefinitely. Every switch that can turn it off
+    /// is checked, not just the registration: a registered <c>ChangeTokenFactory</c> is replaced by the null one
+    /// inside <see cref="InMemoryRedisCacheProvider"/> when its own <c>BroadcastEnable</c> is false, and
+    /// <c>TopicFactory</c> hands out a null provider when <see cref="CacheOptions.BroadcastEnabled"/> is false —
+    /// either leaves the wiring present but inert. Checked when the provider is resolved rather than from a
+    /// completion callback, because <c>AddInMemoryRedis</c> installs its wiring from one and callbacks run in
+    /// registration order, which would make this depend on call order.
+    /// </summary>
+    private static void RequireTierPrerequisites(IServiceProvider sp, string providerName)
+    {
+        if (providerName != KnownCacheProviderNames.InMemoryRedis)
+        {
+            return;
+        }
+
+        if (sp.GetService<IChangeTokenFactory>() is null or NullChangeTokenFactory)
+        {
+            throw new InvalidOperationException(
+                $"AddDistributedCache('{KnownCacheProviderNames.InMemoryRedis}') requires the broadcast wiring installed by AddInMemoryRedis; without it the local cache layer is never invalidated across nodes. Call AddInMemoryRedis on the caching builder, or use the Redis tier.");
+        }
+
+        if (!sp.GetRequiredService<IOptions<InMemoryRedisCacheOptions>>().Value.BroadcastEnable)
+        {
+            throw new InvalidOperationException(
+                $"AddDistributedCache('{KnownCacheProviderNames.InMemoryRedis}') requires broadcast, but InMemoryRedisCacheOptions.BroadcastEnable is false, which replaces the provider's change-token, topic and event factories with null ones. The local layer would never be invalidated across nodes, so a node would serve stale entries indefinitely. Leave it enabled, or use the Redis tier.");
+        }
+
+        if (!sp.GetRequiredService<IOptions<CacheOptions>>().Value.BroadcastEnabled)
+        {
+            throw new InvalidOperationException(
+                $"AddDistributedCache('{KnownCacheProviderNames.InMemoryRedis}') requires broadcast, but CacheOptions.BroadcastEnabled is false, so TopicFactory hands out a null topic provider and the local layer is never invalidated across nodes. Leave it enabled, or use the Redis tier.");
+        }
+    }
+
+    /// <summary>Null keeps the default prefix strategy, which is what separates distributed keys from the application's.</summary>
+    private static ICacheKeyStrategy ResolveCacheKeyStrategy(UiPathDistributedCacheOptions options) =>
+        options.CacheKeyStrategy ?? new PrefixCacheKeyStrategy(UiPathDistributedCacheOptions.DefaultKeyPrefix);
+
+    private static string ResolveRedisKeyDifferentiator(UiPathDistributedCacheOptions options) =>
+        options.RedisKeyDifferentiator ?? UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator;
+
+    /// <summary>
+    /// Both keyspace seams are overridable, so reject values that would merge them back into the application's.
+    /// The prefix comparison ignores case because <see cref="PrefixRedisKeyStrategy"/> lowercases what it is
+    /// given: <c>"H"</c> composes the application's <c>"h"</c> keyspace, which an ordinal match would wave through.
+    /// </summary>
+    private static void EnsureKeyspaceIsolation(UiPathDistributedCacheOptions options)
+    {
+        if (options.RedisKeyDifferentiator is not { } differentiator)
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(differentiator))
+        {
+            throw new InvalidOperationException(
+                "UiPathDistributedCacheOptions.RedisKeyDifferentiator must be a non-empty value, or null to use the default.");
+        }
+
+        if (ApplicationTypePrefixes.Contains(differentiator, StringComparer.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException(
+                $"UiPathDistributedCacheOptions.RedisKeyDifferentiator '{differentiator}' is one of the type prefixes the application's own caches use, which would put the distributed cache in the same Redis keyspace. Choose another value.");
+        }
+    }
+
+    private static CachePolicy? ResolvePolicy(IServiceProvider sp, UiPathDistributedCacheOptions options)
+    {
+        if (options.PolicyName is not { } policyName)
+        {
+            return null;
+        }
+
+        var policy = sp.GetService<ICachePolicyFactory>()?.Resolve(policyName);
+        return policy ?? throw new InvalidOperationException(
+            $"Cache policy '{policyName}' configured on UiPathDistributedCacheOptions.PolicyName is not registered in CacheOptions.Policies.");
+    }
+
+    private static ICacheProvider CreateProvider(IServiceProvider sp, string providerName, UiPathDistributedCacheOptions options)
+    {
+        RequireTierPrerequisites(sp, providerName);
+        var provider = CreateProviderCore(sp, providerName, options, ResolveRedisKeyDifferentiator(options));
+        EnsureBoundedWrites(sp, providerName, options);
+        return provider;
+    }
+
+    /// <summary>
+    /// Writes without a caller expiration take a default TTL; reject configurations where none resolves, or
+    /// resolves non-positive, and unbounded entries are not allowed. The fallback is resolved in the order the
+    /// backing cache applies it, which differs by case: a named policy passed per-operation beats the tier
+    /// default (<see cref="MultilayerCacheBase"/>), but with no named policy the cache builds its default from
+    /// the tier default as the primary and the factory default as the fallback
+    /// (<see cref="CachePolicyMerger"/>), so the tier default wins there.
+    /// </summary>
+    private static void EnsureBoundedWrites(IServiceProvider sp, string providerName, UiPathDistributedCacheOptions options)
+    {
+        if (options.AllowUnboundedEntries && options.DefaultEntryExpiration is not null)
+        {
+            throw new InvalidOperationException(
+                "UiPathDistributedCacheOptions.AllowUnboundedEntries and DefaultEntryExpiration both describe what a write with no caller expiration should do; set one or the other.");
+        }
+
+        if (options.DefaultEntryExpiration is { } configured && configured <= TimeSpan.Zero)
+        {
+            throw new InvalidOperationException(
+                $"UiPathDistributedCacheOptions.DefaultEntryExpiration must be positive, but was {configured}. A non-positive default would make writes without a caller expiration expire immediately.");
+        }
+
+        if (options.AllowUnboundedEntries || options.DefaultEntryExpiration is not null)
+        {
+            return;
+        }
+
+        TimeSpan? tierDefault = providerName switch
+        {
+            KnownCacheProviderNames.Redis => sp.GetRequiredService<IOptions<RedisCacheOptions>>().Value.DefaultExpiration,
+            KnownCacheProviderNames.InMemoryRedis => sp.GetRequiredService<IOptions<InMemoryRedisCacheOptions>>().Value.DefaultExpiration,
+            _ => sp.GetRequiredService<IOptions<InMemoryCacheOptions>>().Value.DefaultExpiration,
+        };
+        var fallback = ResolvePolicy(sp, options) is { } named
+            ? named.DistributedExpiration ?? tierDefault
+            : tierDefault ?? sp.GetService<ICachePolicyFactory>()?.Default?.DistributedExpiration;
+
+        if (fallback is { } resolved)
+        {
+            if (resolved <= TimeSpan.Zero)
+            {
+                throw new InvalidOperationException(
+                    $"AddDistributedCache('{providerName}') resolved {resolved} as the expiration for writes without a caller expiration, so they would expire immediately. Correct the provider's DefaultExpiration or the policy's DistributedExpiration, or set UiPathDistributedCacheOptions.DefaultEntryExpiration.");
+            }
+        }
+        else
+        {
+            throw new InvalidOperationException(
+                $"AddDistributedCache('{providerName}') would store entries without an expiration: the provider's DefaultExpiration is null and no cache policy supplies DistributedExpiration. Set UiPathDistributedCacheOptions.DefaultEntryExpiration, configure the provider's DefaultExpiration, or set AllowUnboundedEntries.");
+        }
+    }
+
+    private static ICacheProvider CreateProviderCore(
+        IServiceProvider sp, string providerName, UiPathDistributedCacheOptions options, string differentiator) =>
+        providerName switch
+        {
+            KnownCacheProviderNames.Redis => CreateRedisProvider(sp, options, differentiator),
+            KnownCacheProviderNames.InMemoryRedis => new InMemoryRedisCacheProvider(
+                Options.Create(WithNeutralCacheKeyStrategy(sp.GetRequiredService<IOptions<InMemoryRedisCacheOptions>>().Value)),
+                sp.GetRequiredService<IOptions<CacheOptions>>(),
+                sp.GetRequiredService<IMemoryCacheFactory>(),
+                () => CreatePrivateRedisFactory(sp, options, differentiator),
+                sp.GetRequiredService<IChangeTokenFactory>(),
+                sp.GetRequiredService<ITopicFactory>(),
+                sp.GetRequiredService<ICacheEventFactory>(),
+                sp.GetRequiredService<ICachingTelemetryProvider>(),
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<ILocalLock>(),
+                sp.GetRequiredService<IDistributedLock>(),
+                sp.GetRequiredService<ICachePolicyFactory>()),
+            KnownCacheProviderNames.InMemory => new InMemoryCacheProvider(
+                Options.Create(WithNeutralCacheKeyStrategy(sp.GetRequiredService<IOptions<InMemoryCacheOptions>>().Value)),
+                sp.GetRequiredService<IOptions<CacheOptions>>(),
+                sp.GetRequiredService<IMemoryCacheFactory>(),
+                sp.GetRequiredService<ICacheEventFactory>(),
+                sp.GetRequiredService<IChangeTokenFactory>(),
+                sp.GetRequiredService<ITopicFactory>(),
+                sp.GetRequiredService<ICachingTelemetryProvider>(),
+                sp.GetRequiredService<ILoggerFactory>(),
+                sp.GetRequiredService<ILocalLock>(),
+                sp.GetRequiredService<ICachePolicyFactory>()),
+            _ => throw new InvalidOperationException(
+                $"Cache provider '{providerName}' is not supported by AddDistributedCache. " +
+                $"Supported: {KnownCacheProviderNames.Redis}, {KnownCacheProviderNames.InMemoryRedis}, {KnownCacheProviderNames.InMemory}."),
+        };
+
+    /// <summary>
+    /// Sole factory the multilayer tier's L2 resolves <see cref="KnownCacheProviderNames.Redis"/> against, so
+    /// it reaches the distributed-keyspace provider rather than the application's.
+    /// </summary>
+    private static CacheFactory CreatePrivateRedisFactory(
+        IServiceProvider sp, UiPathDistributedCacheOptions options, string differentiator) =>
+        new CacheFactory(
+            sp.GetRequiredService<IOptions<CacheOptions>>(),
+            [CreateRedisProvider(sp, options, differentiator)],
+            sp.GetService<ICachePolicyFactory>());
+
+    /// <summary>
+    /// The connection is resolved before the keyspace is composed, so a missing one still reports itself
+    /// rather than surfacing as whatever the key strategy happens to complain about first.
+    /// </summary>
+    private static RedisCacheProvider CreateRedisProvider(
+        IServiceProvider sp, UiPathDistributedCacheOptions options, string differentiator)
+    {
+        var connector = sp.GetService<IRedisConnector>() ?? throw new InvalidOperationException(
+            "AddDistributedCache with a Redis-backed provider requires a Redis connection. Call AddRedisConnection on the caching builder.");
+        var cacheOptions = sp.GetRequiredService<IOptions<CacheOptions>>();
+
+        return new RedisCacheProvider(
+            Options.Create(WithDistributedKeyspace(
+                sp.GetRequiredService<IOptions<RedisCacheOptions>>().Value,
+                options,
+                cacheOptions.Value,
+                differentiator)),
+            cacheOptions,
+            connector,
+            new RedisValueSerializerProxy(sp.GetRequiredService<ISerializerProxy<byte[]>>()),
+            sp.GetRequiredService<IResiliencePipelineProvider>(),
+            sp.GetRequiredService<ICachingTelemetryProvider>(),
+            sp.GetRequiredService<ILoggerFactory>(),
+            sp.GetRequiredService<ICachePolicyFactory>());
+    }
+
+    /// <summary>
+    /// Copy of the Redis options carrying a distinct key differentiator, so the distributed cache's
+    /// keyspace is disjoint from the application's caches. The DI singleton is left untouched.
+    /// </summary>
+    private static RedisCacheOptions WithDistributedKeyspace(
+        RedisCacheOptions source,
+        UiPathDistributedCacheOptions options,
+        CacheOptions cacheOptions,
+        string differentiator)
+    {
+        var applicationFactory = source.RedisKeyStrategyFactory ?? new DefaultRedisKeyStrategyFactory();
+        var distributedFactory = options.RedisKeyStrategyFactory ?? applicationFactory;
+        EnsureDifferentiatedKeyspace(
+            distributedFactory, applicationFactory, cacheOptions, differentiator, ResolveCacheKeyStrategy(options));
+
+        var copy = source.ShallowCopy();
+        copy.RedisKeyStrategyFactory = new DistributedRedisKeyStrategyFactory(distributedFactory, differentiator);
+        copy.CacheKeyStrategy = new DefaultCacheKeyStrategy();
+        copy.AwaitRefresh = true;
+        return copy;
+    }
+
+    /// <summary>
+    /// Copy of the tier's options with the cache-key strategy neutralized. The multilayer caches apply
+    /// <c>ICacheOptions.CacheKeyStrategy</c> (<c>HashCacheEntryBuilder</c>) on top of the key the adapter has
+    /// already composed, so an application strategy configured on the tier would transform these keys a second
+    /// time — making the stored key tier-dependent, and letting a lossy or ambient-insensitive strategy undo
+    /// the adapter's case-sensitivity. The distributed cache composes its key through
+    /// <see cref="UiPathDistributedCacheOptions.CacheKeyStrategy"/> instead. The DI singleton is left untouched.
+    /// </summary>
+    private static InMemoryCacheOptions WithNeutralCacheKeyStrategy(InMemoryCacheOptions source)
+    {
+        var copy = source.ShallowCopy();
+        copy.CacheKeyStrategy = new DefaultCacheKeyStrategy();
+        return copy;
+    }
+
+    /// <inheritdoc cref="WithNeutralCacheKeyStrategy(InMemoryCacheOptions)"/>
+    private static InMemoryRedisCacheOptions WithNeutralCacheKeyStrategy(InMemoryRedisCacheOptions source)
+    {
+        var copy = source.ShallowCopy();
+        copy.CacheKeyStrategy = new DefaultCacheKeyStrategy();
+        return copy;
+    }
+
+    /// <summary>
+    /// The differentiator only separates the keyspace if the factory honors it. A factory that ignores the
+    /// value it is handed — easy to write, and inherited from the application when it configures its own —
+    /// would put distributed entries under the application's own keys with nothing to show for it, so prove
+    /// the composed keys actually differ instead of assuming. The two factories are kept apart because they
+    /// can differ: when only the distributed one is overridden, the application still uses its own, and
+    /// probing the override against itself would miss an override that lands on a real application key. The
+    /// probe key goes through <paramref name="keyStrategy"/> first, so it has the shape the adapter really
+    /// sends — a Redis strategy keyed on the composed shape would otherwise map live entries onto the
+    /// application's keyspace while the probe sampled a name the adapter never uses.
+    /// </summary>
+    private static void EnsureDifferentiatedKeyspace(
+        IRedisKeyStrategyFactory distributedFactory,
+        IRedisKeyStrategyFactory applicationFactory,
+        CacheOptions cacheOptions,
+        string differentiator,
+        ICacheKeyStrategy keyStrategy)
+    {
+        var probe = keyStrategy.GetCacheKey<byte[]>(new CacheKey("probe", CacheKeyCasing.Sensitive));
+        var distributed = distributedFactory.Create(cacheOptions, differentiator).GetRedisKey(probe);
+
+        foreach (var (description, applicationKey) in ApplicationProbes(applicationFactory, cacheOptions, probe))
+        {
+            if (applicationKey == distributed)
+            {
+                throw new InvalidOperationException(
+                    $"The Redis key strategy maps distributed entries onto the same key as the application's {description} caches, so the two would share one keyspace. Either the differentiator '{differentiator}' is not distinct, or the configured IRedisKeyStrategyFactory ignores the differentiator it is given.");
+            }
+        }
+    }
+
+    /// <summary>
+    /// The keys the application's own Redis caches would produce. <c>RedisCache</c> and <c>RedisHashCache</c>
+    /// resolve their strategy through the <see cref="Type"/> overload, so the probe has to use it too: a custom
+    /// factory may implement the two overloads differently, and comparing only the string one would let a
+    /// colliding layout through. The string overload is still probed, for a factory that only implements that.
+    /// </summary>
+    private static IEnumerable<(string Description, RedisKey Key)> ApplicationProbes(
+        IRedisKeyStrategyFactory inner, CacheOptions cacheOptions, CacheKey probe)
+    {
+        yield return ($"'{RedisTypePrefixes.String}' (ICache)", inner.Create(cacheOptions, typeof(RedisCache)).GetRedisKey(probe));
+        yield return ($"'{RedisTypePrefixes.Hash}' (IHashCache)", inner.Create(cacheOptions, typeof(RedisHashCache)).GetRedisKey(probe));
+
+        foreach (var applicationPrefix in ApplicationTypePrefixes)
+        {
+            yield return ($"'{applicationPrefix}'", inner.Create(cacheOptions, applicationPrefix).GetRedisKey(probe));
+        }
+    }
+
+    /// <summary>
+    /// Forces the differentiator regardless of what the caller asks for, so every cache built from these
+    /// options lands in the distributed keyspace. The application's own factory is kept for everything else.
+    /// </summary>
+    private sealed class DistributedRedisKeyStrategyFactory : IRedisKeyStrategyFactory
+    {
+        private readonly IRedisKeyStrategyFactory _inner;
+        private readonly string _differentiator;
+
+        public DistributedRedisKeyStrategyFactory(IRedisKeyStrategyFactory inner, string differentiator)
+        {
+            _inner = inner;
+            _differentiator = differentiator;
+        }
+
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) =>
+            _inner.Create(options, _differentiator);
+
+        public IRedisKeyStrategy Create(CacheOptions options, string differentiator) =>
+            _inner.Create(options, _differentiator);
+    }
+}

--- a/src/UiPath.Caching/Config/ServiceCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/ServiceCollectionExtensions.cs
@@ -6,10 +6,15 @@ public static class ServiceCollectionExtensions
     private const string DefaultSectionName = "Caching";
 
     public static IServiceCollection AddCaching(this IServiceCollection services, IConfiguration configuration, string sectionName = DefaultSectionName) =>
-        services.AddCaching(configuration, opt => configuration.GetSection(sectionName).Bind(opt), sectionName);
+        services.AddCaching(configuration, configure: null, sectionName);
 
+    /// <summary>
+    /// Binds <see cref="CacheOptions"/> from <paramref name="configuration"/>. The binder is passed by name:
+    /// positionally it lands on the <c>configure</c> parameter instead, where it type-checks as
+    /// <c>Action&lt;ICachingBuilder&gt;</c> and leaves the section unread.
+    /// </summary>
     public static IServiceCollection AddCaching(this IServiceCollection services, IConfigurationSection configuration) =>
-        services.AddCaching(configuration, opt => configuration.Bind(opt));
+        services.AddCaching(configuration, configure: null, configureOptions: opt => configuration.Bind(opt));
 
     public static IServiceCollection AddCaching(this IServiceCollection services, Action<ICachingBuilder> configure) =>
         services.AddCaching(null, configure);
@@ -36,6 +41,8 @@ public static class ServiceCollectionExtensions
             configureOptions(options);
             services.Configure(configureOptions);
         }
+
+        SeedDefaultKeyCasing(options);
 
         if (options.Enabled)
         {
@@ -68,6 +75,25 @@ public static class ServiceCollectionExtensions
             new MemoryCacheFactory(sp.GetService<ISystemClock>(),
             sp.GetService<ILoggerFactory>() ?? NullLoggerFactory.Instance));
         return services;
+    }
+
+    /// <summary>
+    /// Validates the casing and seeds <see cref="CacheKey.DefaultCasing"/>. Called eagerly from
+    /// <c>AddCaching</c>, because a key built before anything resolves <see cref="IOptions{CacheOptions}"/>
+    /// would normalize with the wrong casing, and again from the PostConfigure callback, which is what
+    /// options registered after <c>AddCaching</c> reach. Both paths validate: configuration binding accepts
+    /// an out-of-range enum numerically, and assigning one straight to the global default would be reported
+    /// only by whichever key happened to be built next.
+    /// </summary>
+    internal static void SeedDefaultKeyCasing(CacheOptions options)
+    {
+        if (options.KeyCasing is not (CacheKeyCasing.Insensitive or CacheKeyCasing.Sensitive))
+        {
+            throw new InvalidOperationException(
+                $"CacheOptions.KeyCasing has the unsupported value {(int)options.KeyCasing}. Use {nameof(CacheKeyCasing.Insensitive)} or {nameof(CacheKeyCasing.Sensitive)}.");
+        }
+
+        CacheKey.DefaultCasing = options.KeyCasing;
     }
 
     public static IServiceCollection TryConfigure<TOptions>(this IServiceCollection services, Action<TOptions> configureOptions)

--- a/src/UiPath.Caching/Distributed/NullDistributedCache.cs
+++ b/src/UiPath.Caching/Distributed/NullDistributedCache.cs
@@ -1,0 +1,38 @@
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace UiPath.Caching.Distributed;
+
+/// <summary>
+/// Stand-in used when caching is disabled, so consumers such as <c>AddSession()</c> and DataProtection
+/// still resolve <see cref="IDistributedCache"/> instead of failing at startup. Reads always miss.
+/// </summary>
+internal sealed class NullDistributedCache : IDistributedCache
+{
+    public static readonly NullDistributedCache Instance = new();
+
+    private NullDistributedCache()
+    {
+    }
+
+    public byte[]? Get(string key) => null;
+
+    public Task<byte[]?> GetAsync(string key, CancellationToken token = default) => Task.FromResult<byte[]?>(null);
+
+    public void Refresh(string key)
+    {
+    }
+
+    public Task RefreshAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+
+    public void Remove(string key)
+    {
+    }
+
+    public Task RemoveAsync(string key, CancellationToken token = default) => Task.CompletedTask;
+
+    public void Set(string key, byte[] value, DistributedCacheEntryOptions options)
+    {
+    }
+
+    public Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default) => Task.CompletedTask;
+}

--- a/src/UiPath.Caching/Distributed/RedisValueSerializerProxy.cs
+++ b/src/UiPath.Caching/Distributed/RedisValueSerializerProxy.cs
@@ -1,0 +1,17 @@
+namespace UiPath.Caching.Distributed;
+
+/// <summary>Adapts an <c>ISerializerProxy&lt;byte[]&gt;</c> onto the Redis pipeline for the distributed cache's dedicated instance.</summary>
+internal sealed class RedisValueSerializerProxy(ISerializerProxy<byte[]> inner) : ISerializerProxy<RedisValue>
+{
+    public RedisValue Serialize(object? value) =>
+        inner.Serialize(value);
+
+    public T? Deserialize<T>(RedisValue value) =>
+        value.IsNullOrEmpty ? default : inner.Deserialize<T>(value);
+
+    public bool TryDeserialize<T>(string? value, out T? result) =>
+        inner.TryDeserialize(value, out result);
+
+    public bool TryDeserialize<T>(object? value, out T? result) =>
+        inner.TryDeserialize(value, out result);
+}

--- a/src/UiPath.Caching/Distributed/UiPathDistributedCache.cs
+++ b/src/UiPath.Caching/Distributed/UiPathDistributedCache.cs
@@ -1,0 +1,329 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace UiPath.Caching.Distributed;
+
+/// <summary>
+/// <see cref="IDistributedCache"/> over an <see cref="IHashCache"/>. Keys are always case-sensitive;
+/// each entry is a hash of <c>data</c> plus <c>absexp</c>/<c>sldexp</c> expiration metadata, so a
+/// refresh reads the metadata without transferring the payload.
+/// </summary>
+internal sealed partial class UiPathDistributedCache : IDistributedCache
+{
+    private const string DataField = "data";
+    private const string AbsoluteExpirationField = "absexp";
+    private const string SlidingExpirationField = "sldexp";
+    private const long Absent = -1;
+
+    /// <summary>Headroom left for the gap between this clock reading and the slightly later one inside the backing cache.</summary>
+    private static readonly TimeSpan ClockDriftSlack = TimeSpan.FromMinutes(1);
+
+    private static readonly string[] MetadataFields = [AbsoluteExpirationField, SlidingExpirationField];
+    private static readonly string[] EntryFields = [DataField, AbsoluteExpirationField, SlidingExpirationField];
+
+    private readonly IHashCache _cache;
+    private readonly ICacheKeyStrategy _keyStrategy;
+    private readonly CachePolicy? _policy;
+    private readonly TimeSpan? _defaultEntryExpiration;
+    private readonly bool _allowUnboundedEntries;
+    private readonly bool _slideByRewrite;
+    private readonly ISystemClock _clock;
+    private readonly ILogger _logger;
+
+    /// <param name="keyStrategy">
+    /// Applied to every composed key — <see cref="UiPathDistributedCacheOptions.CacheKeyStrategy"/> as resolved
+    /// by registration. Applied here rather than through the backing provider's own
+    /// <c>ICacheOptions.CacheKeyStrategy</c>, which the Redis tier's hash cache does not consult; going
+    /// through the provider would make the stored key depend on the tier.
+    /// </param>
+    public UiPathDistributedCache(
+        IHashCache cache,
+        UiPathDistributedCacheOptions options,
+        ICacheKeyStrategy keyStrategy,
+        CachePolicy? policy,
+        ILogger logger,
+        ISystemClock? clock = null,
+        bool slideByRewrite = false)
+    {
+        ArgumentNullException.ThrowIfNull(keyStrategy);
+        _cache = cache;
+        _keyStrategy = keyStrategy;
+        _defaultEntryExpiration = options.DefaultEntryExpiration;
+        _allowUnboundedEntries = options.AllowUnboundedEntries;
+        _policy = policy;
+        _slideByRewrite = slideByRewrite;
+        _logger = logger;
+        _clock = clock ?? new SystemClock();
+    }
+
+    public byte[]? Get(string key) =>
+        GetAsync(key).GetAwaiter().GetResult();
+
+    public Task<byte[]?> GetAsync(string key, CancellationToken token = default) =>
+        ReadAsync(key, includeData: true, token).AsTask();
+
+    public void Refresh(string key) =>
+        RefreshAsync(key).GetAwaiter().GetResult();
+
+    public async Task RefreshAsync(string key, CancellationToken token = default) =>
+        _ = await ReadAsync(key, includeData: false, token).ConfigureAwait(false);
+
+    public void Remove(string key) =>
+        RemoveAsync(key).GetAwaiter().GetResult();
+
+    public async Task RemoveAsync(string key, CancellationToken token = default)
+    {
+        var cacheKey = Encode(key);
+        if (!await _cache.RemoveAsync<byte[]>(cacheKey, token).ConfigureAwait(false))
+        {
+            LogRemoveNotApplied(key);
+        }
+    }
+
+    public void Set(string key, byte[] value, DistributedCacheEntryOptions options) =>
+        SetAsync(key, value, options).GetAwaiter().GetResult();
+
+    public async Task SetAsync(string key, byte[] value, DistributedCacheEntryOptions options, CancellationToken token = default)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+        ArgumentNullException.ThrowIfNull(options);
+
+        var cacheKey = Encode(key);
+        var now = _clock.UtcNow;
+        var absolute = ResolveAbsoluteExpiration(now, options);
+        var sliding = options.SlidingExpiration;
+        var fields = new Dictionary<string, byte[]?>(3, StringComparer.Ordinal)
+        {
+            [DataField] = value,
+            [AbsoluteExpirationField] = EncodeTicks(absolute?.UtcTicks),
+            [SlidingExpirationField] = EncodeTicks(sliding?.Ticks),
+        };
+
+        var ttl = ResolveTimeToLive(now, sliding, absolute);
+        if (!await StoreAsync(cacheKey, fields, now, ttl, token).ConfigureAwait(false))
+        {
+            LogWriteNotApplied(key);
+        }
+    }
+
+    /// <summary>
+    /// Writes the entry, honoring "until removed" literally: <see cref="DateTimeOffset.MaxValue"/> persists
+    /// the key. Tested before the configured default so that default cannot silently override the flag.
+    /// </summary>
+    private ValueTask<bool> StoreAsync(
+        CacheKey cacheKey,
+        IDictionary<string, byte[]?> fields,
+        DateTimeOffset now,
+        TimeSpan? ttl,
+        CancellationToken token) =>
+        ttl is null && _allowUnboundedEntries
+            ? _cache.SetAsync(cacheKey, fields, (DateTimeOffset?)DateTimeOffset.MaxValue, _policy, token)
+            : _cache.SetAsync(cacheKey, fields, ttl ?? Clamp(now, _defaultEntryExpiration), _policy, token);
+
+    /// <summary>Composes the storage key by running the configured strategy over the validated caller key.</summary>
+    private CacheKey Encode(string key)
+    {
+        ArgumentNullException.ThrowIfNull(key);
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            throw new ArgumentException("The cache key must contain at least one non-whitespace character.", nameof(key));
+        }
+
+        var cacheKey = new CacheKey(key, CacheKeyCasing.Sensitive);
+        var composed = _keyStrategy.GetCacheKey<byte[]>(cacheKey);
+        if (composed.IsNull)
+        {
+            throw new InvalidOperationException(
+                $"The cache key strategy configured on {nameof(UiPathDistributedCacheOptions)}.{nameof(UiPathDistributedCacheOptions.CacheKeyStrategy)} returned an empty key.");
+        }
+
+        if (composed.Casing != CacheKeyCasing.Sensitive)
+        {
+            throw new InvalidOperationException(
+                $"The cache key strategy configured on {nameof(UiPathDistributedCacheOptions)}.{nameof(UiPathDistributedCacheOptions.CacheKeyStrategy)} returned a {composed.Casing} key, which lowercases the caller's key. {nameof(IDistributedCache)} keys are case-significant; build the result with {nameof(CacheKey)}.{nameof(CacheKey.WithName)} so the mode carries over.");
+        }
+
+        return composed;
+    }
+
+    /// <summary>Shared read path for Get and Refresh: resolves the entry, slides it when due, and returns the payload only when asked for.</summary>
+    private async ValueTask<byte[]?> ReadAsync(string key, bool includeData, CancellationToken token)
+    {
+        var cacheKey = Encode(key);
+        var fields = await _cache
+            .GetAsync<byte[]>(cacheKey, FieldsToRead(includeData), _policy, token)
+            .ConfigureAwait(false);
+        if (fields is null || !TryDecodeMetadata(fields, out var metadata))
+        {
+            return null;
+        }
+
+        var now = _clock.UtcNow;
+        if (IsExpired(metadata.AbsoluteExpiration, now))
+        {
+            return null;
+        }
+
+        if (metadata.SlidingExpiration is { } window)
+        {
+            var target = AddClamped(now, window.Ticks);
+            if (metadata.AbsoluteExpiration is { } cap && cap < target)
+            {
+                target = cap;
+            }
+
+            await SlideAsync(cacheKey, fields, target, token).ConfigureAwait(false);
+        }
+
+        return includeData ? Payload(fields) : null;
+    }
+
+    /// <summary>
+    /// Slide-by-rewrite writes the entry back, so it needs the payload in hand even on a refresh; that
+    /// tier's read is in-process, which makes pulling every field free.
+    /// </summary>
+    private string[] FieldsToRead(bool includeData) =>
+        includeData || _slideByRewrite ? EntryFields : MetadataFields;
+
+    /// <summary>
+    /// Past its absolute deadline. Reported as a miss and left to expire on its own: deleting it here would
+    /// race a writer that has just replaced the value.
+    /// </summary>
+    private static bool IsExpired(DateTimeOffset? absolute, DateTimeOffset now) =>
+        absolute is { } cap && cap <= now;
+
+    /// <summary>
+    /// The stored payload. Metadata without a data field is a hit with an empty payload, because the hash
+    /// layer reports a zero-length value as absent.
+    /// </summary>
+    private static byte[] Payload(IDictionary<string, byte[]?> fields) =>
+        fields.TryGetValue(DataField, out var data) && data is not null ? data : [];
+
+    /// <summary>
+    /// Extends the entry's deadline. Memory-backed tiers write it back instead of refreshing, because their
+    /// refresh evicts the local entry and the inner cache cannot restore it.
+    /// </summary>
+    private async ValueTask SlideAsync(
+        CacheKey cacheKey,
+        IDictionary<string, byte[]?> fields,
+        DateTimeOffset target,
+        CancellationToken token)
+    {
+        if (_slideByRewrite)
+        {
+            _ = await _cache.SetAsync(cacheKey, fields, new HashCacheEntryOptions(target), _policy, token).ConfigureAwait(false);
+            return;
+        }
+
+        _ = await _cache.RefreshAsync<byte[]>(cacheKey, (DateTimeOffset?)target, _policy, token).ConfigureAwait(false);
+    }
+
+    /// <summary>Expiration metadata as written, decoded once. Null means the sentinel: that deadline was not set.</summary>
+    private readonly record struct EntryMetadata(DateTimeOffset? AbsoluteExpiration, TimeSpan? SlidingExpiration);
+
+    /// <summary>
+    /// Decodes both expiration fields, or reports a miss. The accepted values are exactly the ones a write can
+    /// produce, so a stored entry always round-trips and anything else — a field the hash layer returned with a
+    /// null value because the key is absent, an empty value, text that does not parse, or a number outside the
+    /// field's range — is a miss. Presence and meaning are settled in this one pass on purpose: deciding them
+    /// separately let a value satisfy the presence test and then decode to "no expiration", which serves the
+    /// payload as an entry that never expires.
+    /// </summary>
+    private static bool TryDecodeMetadata(IDictionary<string, byte[]?> fields, out EntryMetadata metadata)
+    {
+        metadata = default;
+        if (!TryDecodeTicks(fields, AbsoluteExpirationField, DateTime.MaxValue.Ticks, out var absoluteTicks)
+            || !TryDecodeTicks(fields, SlidingExpirationField, TimeSpan.MaxValue.Ticks, out var slidingTicks))
+        {
+            return false;
+        }
+
+        metadata = new EntryMetadata(
+            absoluteTicks is { } deadline ? new DateTimeOffset(deadline, TimeSpan.Zero) : null,
+            slidingTicks is { } window ? new TimeSpan(window) : null);
+        return true;
+    }
+
+    /// <summary>
+    /// One field. True with a value, true with null for the <see cref="Absent"/> sentinel, false when the field
+    /// holds something no write could have produced. A write emits either the sentinel or a strictly positive
+    /// tick count within the field's range: an absolute deadline is required to be in the future, and
+    /// <see cref="DistributedCacheEntryOptions.SlidingExpiration"/> only permits positive durations. Only a
+    /// leading sign is tolerated around the digits, because that is all <see cref="EncodeTicks"/> emits.
+    /// </summary>
+    private static bool TryDecodeTicks(IDictionary<string, byte[]?> fields, string field, long maxTicks, out long? ticks)
+    {
+        ticks = null;
+        if (!fields.TryGetValue(field, out var raw)
+            || raw is null or { Length: 0 }
+            || !long.TryParse(Encoding.UTF8.GetString(raw), NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture, out var value))
+        {
+            return false;
+        }
+
+        if (value == Absent)
+        {
+            return true;
+        }
+
+        if (value < 1 || value > maxTicks)
+        {
+            return false;
+        }
+
+        ticks = value;
+        return true;
+    }
+
+    private static byte[] EncodeTicks(long? ticks) =>
+        Encoding.UTF8.GetBytes((ticks ?? Absent).ToString(CultureInfo.InvariantCulture));
+
+    private static DateTimeOffset AddClamped(DateTimeOffset now, long ticks)
+    {
+        var remaining = DateTimeOffset.MaxValue.UtcTicks - now.UtcTicks;
+        return ticks >= remaining ? DateTimeOffset.MaxValue : now.AddTicks(ticks);
+    }
+
+    private static TimeSpan? ResolveTimeToLive(DateTimeOffset now, TimeSpan? sliding, DateTimeOffset? absolute)
+    {
+        var remaining = absolute is { } cap ? cap - now : (TimeSpan?)null;
+        var resolved = (sliding, remaining) switch
+        {
+            ({ } window, { } left) => TimeSpan.FromTicks(Math.Min(window.Ticks, left.Ticks)),
+            ({ } window, null) => window,
+            (null, { } left) => left,
+            _ => (TimeSpan?)null,
+        };
+        return Clamp(now, resolved);
+    }
+
+    /// <summary>
+    /// Keeps <c>now + ttl</c> representable. The backing cache turns the TTL into a deadline against its own,
+    /// slightly later, clock reading, so clamping to the exact headroom would still overflow there; the
+    /// allowance matches the one <c>MultilayerCacheBase.ApplyJitter</c> makes.
+    /// </summary>
+    private static TimeSpan? Clamp(DateTimeOffset now, TimeSpan? ttl)
+    {
+        var headroom = Math.Max(0, DateTime.MaxValue.Ticks - now.UtcTicks - ClockDriftSlack.Ticks);
+        return ttl is { } value && value.Ticks > headroom ? new TimeSpan(headroom) : ttl;
+    }
+
+    private static DateTimeOffset? ResolveAbsoluteExpiration(DateTimeOffset now, DistributedCacheEntryOptions options)
+    {
+        if (options.AbsoluteExpiration is { } absolute)
+        {
+            return absolute <= now
+                ? throw new ArgumentOutOfRangeException(nameof(options), absolute, "The absolute expiration must be in the future.")
+                : absolute;
+        }
+
+        return options.AbsoluteExpirationRelativeToNow is { } relative ? AddClamped(now, relative.Ticks) : null;
+    }
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Distributed cache write for key {Key} was not applied by the backing cache.")]
+    private partial void LogWriteNotApplied(string key);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Distributed cache remove for key {Key} reported no change.")]
+    private partial void LogRemoveNotApplied(string key);
+}

--- a/src/UiPath.Caching/Distributed/UiPathDistributedCacheOptions.cs
+++ b/src/UiPath.Caching/Distributed/UiPathDistributedCacheOptions.cs
@@ -1,0 +1,56 @@
+namespace UiPath.Caching.Distributed;
+
+public class UiPathDistributedCacheOptions
+{
+    /// <summary>Prefix applied by the default <see cref="CacheKeyStrategy"/>.</summary>
+    internal const string DefaultKeyPrefix = "d";
+
+    /// <summary>Differentiator used by default for the Redis keyspace; see <see cref="RedisKeyDifferentiator"/>.</summary>
+    internal const string DefaultRedisKeyDifferentiator = "dh";
+
+    /// <summary>
+    /// Composes the storage key from the caller key. Null applies
+    /// <see cref="PrefixCacheKeyStrategy"/> with the prefix <c>"d"</c>, which is what keeps a
+    /// distributed entry out of reach of the application's own <see cref="ICache"/>/<see cref="IHashCache"/>
+    /// — including the local lock keyspace, which the memory tiers key by provider name plus cache key.
+    /// Replacing it makes that separation yours to preserve; <see cref="DefaultCacheKeyStrategy"/> opts out
+    /// of prefixing entirely.
+    /// </summary>
+    public ICacheKeyStrategy? CacheKeyStrategy { get; set; }
+
+    /// <summary>
+    /// Differentiator handed to the Redis key strategy, placed after <c>AppShortName</c>, in the slot the
+    /// application's own caches fill with a <see cref="RedisTypePrefixes"/> value. Null uses <c>"dh"</c>.
+    /// Inert on the InMemory tier, and a value matching one of the application's type prefixes is rejected
+    /// at registration.
+    /// </summary>
+    public string? RedisKeyDifferentiator { get; set; }
+
+    /// <summary>
+    /// Builds the Redis key from the composed <see cref="CacheKey"/>, receiving
+    /// <see cref="RedisKeyDifferentiator"/>. Null uses the one the application configured on
+    /// <see cref="RedisCacheOptions.RedisKeyStrategyFactory"/>, so the distributed cache inherits its
+    /// <c>AppShortName</c>, separator and sharding conventions. Set this to take over the layout entirely —
+    /// for a mandated key shape, or a cluster hash-tag scheme. Registration proves the resulting keys differ
+    /// from the application's, so a factory that ignores the differentiator is rejected rather than silently
+    /// sharing the keyspace.
+    /// </summary>
+    public IRedisKeyStrategyFactory? RedisKeyStrategyFactory { get; set; }
+
+    /// <summary>Optional <see cref="CachePolicy"/> name, resolved at registration; absent, the provider's default policy applies.</summary>
+    public string? PolicyName { get; set; }
+
+    /// <summary>
+    /// Expiration applied when the caller supplies none. <see cref="IDistributedCache"/> treats absent
+    /// expiration as "until removed"; unless <see cref="AllowUnboundedEntries"/> is set, that is mapped
+    /// to this value so shared storage cannot accumulate unbounded keys. Null falls back to the backing
+    /// tier's default expiration.
+    /// </summary>
+    public TimeSpan? DefaultEntryExpiration { get; set; }
+
+    /// <summary>
+    /// Honor "no expiration" literally instead of substituting a bounded default. Off by default:
+    /// registration fails when no bounded default can be resolved.
+    /// </summary>
+    public bool AllowUnboundedEntries { get; set; }
+}

--- a/src/UiPath.Caching/InMemoryCacheOptions.cs
+++ b/src/UiPath.Caching/InMemoryCacheOptions.cs
@@ -89,6 +89,9 @@ public class InMemoryCacheOptions : IMultilayerCacheOptions, IMemoryCacheOptions
     public TimeSpan? DistributedLockExpiry { get; set; }
 
     public IDistributedLockKeyStrategy? LockKeyStrategy { get; set; }
+
+    /// <summary>Member-wise copy, so a caller can vary one setting without mutating the DI singleton.</summary>
+    internal InMemoryCacheOptions ShallowCopy() => (InMemoryCacheOptions)MemberwiseClone();
 }
 
 #pragma warning restore S1133

--- a/src/UiPath.Caching/InMemoryRedisCacheOptions.cs
+++ b/src/UiPath.Caching/InMemoryRedisCacheOptions.cs
@@ -94,6 +94,9 @@ public class InMemoryRedisCacheOptions : IMultilayerCacheOptions, IMemoryCacheOp
     public TimeSpan? DistributedLockExpiry { get; set; } = TimeSpan.FromSeconds(5);
 
     public IDistributedLockKeyStrategy? LockKeyStrategy { get; set; }
+
+    /// <summary>Member-wise copy, so a caller can vary one setting without mutating the DI singleton.</summary>
+    internal InMemoryRedisCacheOptions ShallowCopy() => (InMemoryRedisCacheOptions)MemberwiseClone();
 }
 
 #pragma warning restore S1133

--- a/src/UiPath.Caching/PrefixCacheKeyStrategy.cs
+++ b/src/UiPath.Caching/PrefixCacheKeyStrategy.cs
@@ -11,5 +11,6 @@ public sealed class PrefixCacheKeyStrategy : ICacheKeyStrategy
         _separator = separator == null ? CacheOptions.KeySeparator :  char.ToLowerInvariant(Guard.NotWhiteSpace(separator.Value, nameof(separator)));
     }
     
-    public CacheKey GetCacheKey<T>(CacheKey key) => string.Join(_separator, _prefix, key);
+    public CacheKey GetCacheKey<T>(CacheKey key) =>
+        key.WithName(string.Join(_separator, _prefix, key.Name));
 }

--- a/src/UiPath.Caching/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Unshipped.txt
@@ -1,1 +1,20 @@
 #nullable enable
+const UiPath.Caching.Config.DistributedCacheCollectionExtensions.DistributedCacheServiceKey = "UiPath.Caching.Distributed" -> string!
+static UiPath.Caching.Config.DistributedCacheCollectionExtensions.AddDistributedCache(this UiPath.Caching.Config.ICachingBuilder! builder, string! providerName, System.Action<UiPath.Caching.Distributed.UiPathDistributedCacheOptions!>? configure = null) -> UiPath.Caching.Config.ICachingBuilder!
+UiPath.Caching.Config.DistributedCacheCollectionExtensions
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.PolicyName.get -> string?
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.PolicyName.set -> void
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.UiPathDistributedCacheOptions() -> void
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.DefaultEntryExpiration.get -> System.TimeSpan?
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.DefaultEntryExpiration.set -> void
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.AllowUnboundedEntries.get -> bool
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.AllowUnboundedEntries.set -> void
+UiPath.Caching.Redis.RedisCacheOptions.AwaitRefresh.get -> bool
+UiPath.Caching.Redis.RedisCacheOptions.AwaitRefresh.set -> void
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.CacheKeyStrategy.get -> UiPath.Caching.ICacheKeyStrategy?
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.CacheKeyStrategy.set -> void
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.RedisKeyDifferentiator.get -> string?
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.RedisKeyDifferentiator.set -> void
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.RedisKeyStrategyFactory.get -> UiPath.Caching.Redis.IRedisKeyStrategyFactory?
+UiPath.Caching.Distributed.UiPathDistributedCacheOptions.RedisKeyStrategyFactory.set -> void

--- a/src/UiPath.Caching/Redis/RedisCache.cs
+++ b/src/UiPath.Caching/Redis/RedisCache.cs
@@ -163,7 +163,7 @@ internal sealed partial class RedisCache : RedisCacheBase, ICache
                 ret = await _write.ExecuteAsync(async token =>
                 {
                     token.ThrowIfCancellationRequested();
-                    return await Database.KeyPersistAsync(redisKey, CommandFlags.DemandMaster | CommandFlags.FireAndForget).ConfigureAwait(false);
+                    return await Database.KeyPersistAsync(redisKey, RefreshFlags).ConfigureAwait(false);
                 }, default, token).ConfigureAwait(false);
             }
             else
@@ -171,7 +171,7 @@ internal sealed partial class RedisCache : RedisCacheBase, ICache
                 ret = await _write.ExecuteAsync(async token =>
                 {
                     token.ThrowIfCancellationRequested();
-                    return await Database.KeyExpireAsync(redisKey, expiration.Value.UtcDateTime, CommandFlags.DemandMaster | CommandFlags.FireAndForget).ConfigureAwait(false);
+                    return await Database.KeyExpireAsync(redisKey, expiration.Value.UtcDateTime, RefreshFlags).ConfigureAwait(false);
                 }, default, token).ConfigureAwait(false);
             }
             operation.Stop();

--- a/src/UiPath.Caching/Redis/RedisCacheBase.cs
+++ b/src/UiPath.Caching/Redis/RedisCacheBase.cs
@@ -26,11 +26,17 @@ public abstract class RedisCacheBase : IConnectionState, IDisposable
         DefaultExpiration = DefaultPolicy.DistributedExpiration;
         Clock = new CacheClock(redisCacheOptions.Clock, DefaultExpiration);
         KeyReadTelemetryEnabled = redisCacheOptions.KeyReadTelemetryEnabled;
+        RefreshFlags = redisCacheOptions.AwaitRefresh
+            ? CommandFlags.DemandMaster
+            : CommandFlags.DemandMaster | CommandFlags.FireAndForget;
     }
 
     protected ICachingTelemetryProvider Telemetry { get; }
 
     protected bool KeyReadTelemetryEnabled { get; }
+
+    /// <summary>Flags for a standalone TTL write, shared by both caches so the option cannot be honored in one and not the other.</summary>
+    internal CommandFlags RefreshFlags { get; }
 
     protected void TrackRead(ITelemetryOperation operation, bool hit, RedisKey key)
     {

--- a/src/UiPath.Caching/Redis/RedisCacheOptions.cs
+++ b/src/UiPath.Caching/Redis/RedisCacheOptions.cs
@@ -23,4 +23,15 @@ public class RedisCacheOptions : ICacheOptions
     public bool CacheNullValues { get; set; }
 
     public bool KeyReadTelemetryEnabled { get; set; }
+
+    /// <summary>
+    /// Wait for the server to apply a refresh rather than sending it fire-and-forget. Off by default, keeping
+    /// the round trip off the sliding-expiration path. Fire-and-forget makes a refresh unverifiable:
+    /// <c>RefreshAsync</c> returns <see langword="false"/> either way, a rejection is neither logged nor
+    /// retried, and the new deadline is not yet in effect when the call returns.
+    /// </summary>
+    public bool AwaitRefresh { get; set; }
+
+    /// <summary>Member-wise copy, so a caller can vary one setting without mutating the DI singleton.</summary>
+    internal RedisCacheOptions ShallowCopy() => (RedisCacheOptions)MemberwiseClone();
 }

--- a/src/UiPath.Caching/Redis/RedisHashCache.cs
+++ b/src/UiPath.Caching/Redis/RedisHashCache.cs
@@ -244,12 +244,12 @@ internal sealed partial class RedisHashCache : RedisCacheBase, IHashCache
                 ? await _write.ExecuteAsync(async token =>
                 {
                     token.ThrowIfCancellationRequested();
-                    return await Database.KeyExpireAsync(redisKey, localExpiration.UtcDateTime, CommandFlags.DemandMaster | CommandFlags.FireAndForget).ConfigureAwait(false);
+                    return await Database.KeyExpireAsync(redisKey, localExpiration.UtcDateTime, RefreshFlags).ConfigureAwait(false);
                 }, default, token).ConfigureAwait(false)
                 : await _write.ExecuteAsync(async token =>
                 {
                     token.ThrowIfCancellationRequested();
-                    return await Database.KeyPersistAsync(redisKey, CommandFlags.DemandMaster | CommandFlags.FireAndForget).ConfigureAwait(false);
+                    return await Database.KeyPersistAsync(redisKey, RefreshFlags).ConfigureAwait(false);
                 }, default, token).ConfigureAwait(false);
             operation.Stop();
         }

--- a/tests/UiPath.Caching.Tests/CacheKeyCasingTest.cs
+++ b/tests/UiPath.Caching.Tests/CacheKeyCasingTest.cs
@@ -1,0 +1,61 @@
+namespace UiPath.Caching.Tests;
+
+public class CacheKeyCasingTest
+{
+    [Fact]
+    public void Insensitive_ctor_trims_and_lowercases()
+    {
+        var key = new CacheKey("  AbC  ", CacheKeyCasing.Insensitive);
+        key.Name.Should().Be("abc");
+        key.Casing.Should().Be(CacheKeyCasing.Insensitive);
+    }
+
+    [Fact]
+    public void Sensitive_ctor_trims_only()
+    {
+        var key = new CacheKey("  AbC  ", CacheKeyCasing.Sensitive);
+        key.Name.Should().Be("AbC");
+        key.Casing.Should().Be(CacheKeyCasing.Sensitive);
+    }
+
+    [Fact]
+    public void Sensitive_keys_with_different_case_are_not_equal()
+    {
+        var upper = new CacheKey("AbC", CacheKeyCasing.Sensitive);
+        var lower = new CacheKey("abc", CacheKeyCasing.Sensitive);
+        upper.Should().NotBe(lower);
+        (upper != lower).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equality_ignores_casing_mode_when_names_match()
+    {
+        var viaSensitive = new CacheKey("abc", CacheKeyCasing.Sensitive);
+        var viaInsensitive = new CacheKey("ABC", CacheKeyCasing.Insensitive);
+        viaSensitive.Should().Be(viaInsensitive);
+        viaSensitive.GetHashCode().Should().Be(viaInsensitive.GetHashCode());
+    }
+
+    [Fact]
+    public void WithName_preserves_casing()
+    {
+        var key = new CacheKey("AbC", CacheKeyCasing.Sensitive);
+        var derived = key.WithName("prefix:" + key.Name);
+        derived.Name.Should().Be("prefix:AbC");
+        derived.Casing.Should().Be(CacheKeyCasing.Sensitive);
+    }
+
+    [Fact]
+    public void Default_struct_is_insensitive_and_null()
+    {
+        default(CacheKey).Casing.Should().Be(CacheKeyCasing.Insensitive);
+        default(CacheKey).IsNull.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Sensitive_null_and_whitespace_still_map_to_empty()
+    {
+        new CacheKey(null, CacheKeyCasing.Sensitive).IsNull.Should().BeTrue();
+        new CacheKey("   ", CacheKeyCasing.Sensitive).IsNull.Should().BeTrue();
+    }
+}

--- a/tests/UiPath.Caching.Tests/CacheKeyComparerTest.cs
+++ b/tests/UiPath.Caching.Tests/CacheKeyComparerTest.cs
@@ -1,0 +1,56 @@
+namespace UiPath.Caching.Tests;
+
+public class CacheKeyComparerTest
+{
+    [Fact]
+    public void Sensitive_distinguishes_case()
+    {
+        var upper = new CacheKey("AbC", CacheKeyCasing.Sensitive);
+        var lower = new CacheKey("abc", CacheKeyCasing.Sensitive);
+        CacheKeyComparer.Sensitive.Equals(upper, lower).Should().BeFalse();
+        CacheKeyComparer.Sensitive.Equals(upper, new CacheKey("AbC", CacheKeyCasing.Sensitive)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Insensitive_folds_case()
+    {
+        var upper = new CacheKey("AbC", CacheKeyCasing.Sensitive);
+        var lower = new CacheKey("abc", CacheKeyCasing.Sensitive);
+        CacheKeyComparer.Insensitive.Equals(upper, lower).Should().BeTrue();
+        CacheKeyComparer.Insensitive.GetHashCode(upper).Should().Be(CacheKeyComparer.Insensitive.GetHashCode(lower));
+    }
+
+    [Fact]
+    public void Hash_is_consistent_with_equals()
+    {
+        var a = new CacheKey("session:x", CacheKeyCasing.Sensitive);
+        var b = new CacheKey("session:x", CacheKeyCasing.Insensitive);
+        CacheKeyComparer.Sensitive.Equals(a, b).Should().BeTrue();
+        CacheKeyComparer.Sensitive.GetHashCode(a).Should().Be(CacheKeyComparer.Sensitive.GetHashCode(b));
+    }
+
+    [Fact]
+    public void Works_as_hashset_comparer()
+    {
+        var set = new HashSet<CacheKey>(CacheKeyComparer.Insensitive)
+        {
+            new("AbC", CacheKeyCasing.Sensitive),
+        };
+        set.Add(new CacheKey("abc", CacheKeyCasing.Sensitive)).Should().BeFalse();
+        set.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Singletons_are_cached()
+    {
+        CacheKeyComparer.Sensitive.Should().BeSameAs(CacheKeyComparer.Sensitive);
+        CacheKeyComparer.Insensitive.Should().BeSameAs(CacheKeyComparer.Insensitive);
+    }
+
+    [Fact]
+    public void Default_key_does_not_throw()
+    {
+        CacheKeyComparer.Sensitive.GetHashCode(default).Should().Be(CacheKeyComparer.Sensitive.GetHashCode(default));
+        CacheKeyComparer.Insensitive.Equals(default, default).Should().BeTrue();
+    }
+}

--- a/tests/UiPath.Caching.Tests/Config/DistributedCacheRegistrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Config/DistributedCacheRegistrationTests.cs
@@ -1,0 +1,585 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+using UiPath.Caching.Config;
+using UiPath.Caching.Distributed;
+using UiPath.Caching.Redis;
+
+namespace UiPath.Caching.Tests.Config;
+
+public class DistributedCacheRegistrationTests
+{
+    private static ServiceProvider Build(string providerName, Action<UiPathDistributedCacheOptions>? configure = null)
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b =>
+        {
+            b.AddMemory(_ => { });
+            b.AddDistributedCache(providerName, configure);
+        });
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public void InMemory_tier_works_without_AddMemory()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b => b.AddDistributedCache(KnownCacheProviderNames.InMemory));
+        using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        cache.Set("k", [1], new DistributedCacheEntryOptions());
+
+        cache.Get("k").Should().Equal(1);
+    }
+
+    [Fact]
+    public void Null_default_expiration_without_policy_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b =>
+        {
+            b.Services.Configure<InMemoryCacheOptions>(o => o.DefaultExpiration = null);
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*DefaultExpiration*DistributedExpiration*");
+    }
+
+    [Fact]
+    public void Null_default_expiration_is_accepted_when_a_policy_bounds_writes()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.Configure<InMemoryCacheOptions>(o => o.DefaultExpiration = null);
+                b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+            },
+            o => o.DefaultCachePolicy = new CachePolicy { DistributedExpiration = TimeSpan.FromMinutes(5) });
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IDistributedCache>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Redis_tier_without_a_connection_fails_with_guidance()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b => b.AddDistributedCache(KnownCacheProviderNames.Redis));
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AddRedisConnection*");
+    }
+
+    [Fact]
+    public void Resolves_IDistributedCache_and_keyed_cache()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory);
+        provider.GetRequiredService<IDistributedCache>().Should().BeOfType<UiPathDistributedCache>();
+        provider.GetRequiredKeyedService<IHashCache>(DistributedCacheCollectionExtensions.DistributedCacheServiceKey)
+            .Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Keyed_cache_is_a_separate_instance_from_the_apps_cache()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory);
+        var appCache = provider.GetRequiredService<ICacheFactory>().CreateHashCache(KnownCacheProviderNames.InMemory);
+        var distributedCache = provider.GetRequiredKeyedService<IHashCache>(DistributedCacheCollectionExtensions.DistributedCacheServiceKey);
+        distributedCache.Should().NotBeSameAs(appCache);
+    }
+
+    [Fact]
+    public void Unknown_provider_name_fails_fast_with_supported_names()
+    {
+        using var provider = Build("NoSuchProvider");
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*NoSuchProvider*").WithMessage("*Redis*InMemoryRedis*InMemory*");
+    }
+
+    [Fact]
+    public void Round_trips_through_the_real_pipeline()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        cache.Set("AbC", [1, 2, 3], new DistributedCacheEntryOptions());
+
+        cache.Get("AbC").Should().Equal(1, 2, 3);
+        cache.Get("abc").Should().BeNull();
+    }
+
+    [Fact]
+    public void Non_positive_default_entry_expiration_fails_fast()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory, o => o.DefaultEntryExpiration = TimeSpan.Zero);
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*DefaultEntryExpiration must be positive*");
+    }
+
+    [Fact]
+    public void Unbounded_entries_and_a_default_expiration_together_fail_fast()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory, o =>
+        {
+            o.AllowUnboundedEntries = true;
+            o.DefaultEntryExpiration = TimeSpan.FromHours(1);
+        });
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*set one or the other*");
+    }
+
+
+    [Fact]
+    public void Custom_cache_key_strategy_is_honored_end_to_end()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory,
+            o => o.CacheKeyStrategy = new PrefixCacheKeyStrategy("mine"));
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        cache.Set("k", [1], new DistributedCacheEntryOptions());
+
+        cache.Get("k").Should().Equal(1);
+    }
+
+    [Fact]
+    public void Blank_redis_key_differentiator_fails_fast()
+    {
+        var act = () => Build(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "  ");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*RedisKeyDifferentiator must be a non-empty value*");
+    }
+
+    [Theory]
+    [InlineData(RedisTypePrefixes.String)]
+    [InlineData(RedisTypePrefixes.Hash)]
+    [InlineData(RedisTypePrefixes.PubSub)]
+    [InlineData(RedisTypePrefixes.Streams)]
+    [InlineData("H")]
+    [InlineData("ST")]
+    public void Redis_key_differentiator_colliding_with_an_application_prefix_fails_fast(string differentiator)
+    {
+        var act = () => Build(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = differentiator);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*same Redis keyspace*");
+    }
+
+    [Fact]
+    public void Custom_redis_key_strategy_factory_is_used_over_the_applications()
+    {
+        var services = new ServiceCollection();
+        var factory = new RecordingRedisKeyStrategyFactory();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedis(_ => { });
+                b.AddDistributedCache(KnownCacheProviderNames.Redis, o => o.RedisKeyStrategyFactory = factory);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        _ = provider.GetRequiredService<IDistributedCache>();
+
+        factory.Differentiators.Should().Contain(UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator);
+    }
+
+    /// <summary>
+    /// A distributed-only override is probed against the application's own factory, not against itself:
+    /// otherwise an override landing on a real application key passes by returning something else from its own
+    /// type overloads.
+    /// </summary>
+    [Fact]
+    public void Distributed_only_factory_landing_on_an_application_key_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedis(_ => { });
+                b.AddDistributedCache(KnownCacheProviderNames.Redis,
+                    o => o.RedisKeyStrategyFactory = new ApplicationHashImpersonatingFactory());
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*share one keyspace*");
+    }
+
+    /// <summary>
+    /// Composes the application's hash keyspace whatever differentiator it is handed, while its own type
+    /// overloads answer differently — so only comparing against the application's factory catches it.
+    /// </summary>
+    private sealed class ApplicationHashImpersonatingFactory : IRedisKeyStrategyFactory
+    {
+        private readonly DefaultRedisKeyStrategyFactory _inner = new();
+
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) =>
+            _inner.Create(options, "elsewhere");
+
+        public IRedisKeyStrategy Create(CacheOptions options, string differentiator) =>
+            _inner.Create(options, RedisTypePrefixes.Hash);
+    }
+
+    /// <summary>
+    /// The application's own factory is inherited when the distributed cache does not override it, so one that
+    /// composes the same key whatever differentiator it is handed puts both caches on one keyspace.
+    /// </summary>
+    [Fact]
+    public void Inherited_factory_that_ignores_the_differentiator_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedis(o => o.RedisKeyStrategyFactory = new FixedRedisKeyStrategyFactory());
+                b.AddDistributedCache(KnownCacheProviderNames.Redis);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*share one keyspace*");
+    }
+
+    /// <summary>
+    /// The guard is about collision, not about honoring the argument: a distributed-only factory may ignore the
+    /// differentiator as long as the keyspace it produces is disjoint from the application's.
+    /// </summary>
+    [Fact]
+    public void Distributed_only_factory_on_a_disjoint_keyspace_is_accepted()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedis(_ => { });
+                b.AddDistributedCache(KnownCacheProviderNames.Redis,
+                    o => o.RedisKeyStrategyFactory = new FixedRedisKeyStrategyFactory());
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IDistributedCache>().Should().NotBeNull();
+    }
+
+    private sealed class RecordingRedisKeyStrategyFactory : IRedisKeyStrategyFactory
+    {
+        private readonly DefaultRedisKeyStrategyFactory _inner = new();
+
+        public List<string> Differentiators { get; } = [];
+
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) => _inner.Create(options, cacheType);
+
+        public IRedisKeyStrategy Create(CacheOptions options, string differentiator)
+        {
+            Differentiators.Add(differentiator);
+            return _inner.Create(options, differentiator);
+        }
+    }
+
+    private sealed class FixedRedisKeyStrategyFactory : IRedisKeyStrategyFactory
+    {
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) => Create(options, "ignored");
+
+        public IRedisKeyStrategy Create(CacheOptions options, string differentiator) =>
+            new PrefixRedisKeyStrategy("fixed", options.Separator);
+    }
+
+    /// <summary>
+    /// The prerequisite check must not depend on call order: AddInMemoryRedis installs the broadcast wiring
+    /// from its own completion callback, and callbacks run in registration order.
+    /// </summary>
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void InMemoryRedis_tier_accepts_AddInMemoryRedis_in_either_order(bool distributedFirst)
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                if (distributedFirst)
+                {
+                    b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
+                    b.AddInMemoryRedis(_ => { });
+                }
+                else
+                {
+                    b.AddInMemoryRedis(_ => { });
+                    b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
+                }
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        provider.GetRequiredService<IDistributedCache>().Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// Broadcast can be present but inert: the provider swaps in null factories when its own BroadcastEnable is
+    /// false, and TopicFactory hands out a null provider when the app-wide switch is off. Either way the local
+    /// layer is never invalidated across nodes, so the tier is refused rather than serving stale entries.
+    /// </summary>
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    public void InMemoryRedis_tier_with_inert_broadcast_fails_fast(bool providerBroadcast, bool appBroadcast)
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddInMemoryRedis(o => o.BroadcastEnable = providerBroadcast);
+                b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
+            },
+            o =>
+            {
+                o.AppShortName = "app";
+                o.BroadcastEnabled = appBroadcast;
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*requires broadcast*");
+    }
+
+    /// <summary>Without AddInMemoryRedis the local layer is never invalidated across nodes, so the tier is refused.</summary>
+    [Fact]
+    public void InMemoryRedis_tier_without_broadcast_wiring_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AddInMemoryRedis*");
+    }
+
+    /// <summary>
+    /// A dropped sliding refresh silently shortens a session and fire-and-forget cannot report one, so this
+    /// provider awaits — without changing the application's own caches.
+    /// </summary>
+    [Fact]
+    public void Distributed_provider_awaits_refresh_while_the_application_does_not()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedis(_ => { });
+                b.AddDistributedCache(KnownCacheProviderNames.Redis);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var distributed = (RedisCacheBase)provider.GetRequiredKeyedService<IHashCache>(
+            DistributedCacheCollectionExtensions.DistributedCacheServiceKey);
+        var application = (RedisCacheBase)provider.GetRequiredService<ICacheFactory>()
+            .CreateHashCache(KnownCacheProviderNames.Redis);
+
+        distributed.RefreshFlags.Should().Be(CommandFlags.DemandMaster);
+        application.RefreshFlags.Should().Be(CommandFlags.DemandMaster | CommandFlags.FireAndForget);
+        provider.GetRequiredService<IOptions<RedisCacheOptions>>().Value.AwaitRefresh
+            .Should().BeFalse("the DI singleton is left untouched");
+    }
+
+    /// <summary>Both Redis caches must honor the option; one of them ignoring it is the defect this guards.</summary>
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Await_refresh_option_reaches_both_redis_caches(bool awaitRefresh)
+    {
+        var expected = awaitRefresh
+            ? CommandFlags.DemandMaster
+            : CommandFlags.DemandMaster | CommandFlags.FireAndForget;
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedis(o => o.AwaitRefresh = awaitRefresh);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<ICacheFactory>();
+
+        ((RedisCacheBase)factory.CreateCache(KnownCacheProviderNames.Redis)).RefreshFlags.Should().Be(expected);
+        ((RedisCacheBase)factory.CreateHashCache(KnownCacheProviderNames.Redis)).RefreshFlags.Should().Be(expected);
+    }
+
+    /// <summary>A disabled tier yields a null backing cache rather than first demanding that tier's infrastructure.</summary>
+    [Fact]
+    public void Disabled_redis_tier_does_not_require_a_connection()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b =>
+        {
+            b.Services.Configure<RedisCacheOptions>(o => o.Enabled = false);
+            b.AddDistributedCache(KnownCacheProviderNames.Redis);
+        });
+        using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        cache.Set("k", [1], new DistributedCacheEntryOptions());
+
+        cache.Get("k").Should().BeNull();
+    }
+
+    /// <summary>
+    /// The backing cache lets a policy expiration override the tier default, so a healthy tier default must not
+    /// mask a non-positive policy value.
+    /// </summary>
+    [Fact]
+    public void Non_positive_policy_expiration_is_rejected_despite_a_healthy_tier_default()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.Configure<InMemoryCacheOptions>(o => o.DefaultExpiration = TimeSpan.FromHours(1));
+                b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.PolicyName = "vanishing");
+            },
+            o => o.Policies = new Dictionary<string, CachePolicy>
+            {
+                ["vanishing"] = new() { DistributedExpiration = TimeSpan.Zero },
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*would expire immediately*");
+    }
+
+    /// <summary>
+    /// With no named policy the cache builds its default from the tier default as the primary, so a positive
+    /// application default policy must not mask a zero tier default — the real write still uses zero.
+    /// </summary>
+    [Fact]
+    public void Zero_tier_default_is_rejected_even_behind_a_positive_application_default_policy()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.Configure<InMemoryCacheOptions>(o => o.DefaultExpiration = TimeSpan.Zero);
+                b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+            },
+            o => o.DefaultCachePolicy = new CachePolicy { DistributedExpiration = TimeSpan.FromMinutes(5) });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*would expire immediately*");
+    }
+
+    /// <summary>A non-positive tier default would make writes without a caller expiration expire immediately.</summary>
+    [Fact]
+    public void Non_positive_tier_default_expiration_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b =>
+        {
+            b.Services.Configure<InMemoryCacheOptions>(o => o.DefaultExpiration = TimeSpan.Zero);
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+        });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*would expire immediately*");
+    }
+
+    /// <summary>A non-positive policy expiration is rejected the same way when it is the resolved fallback.</summary>
+    [Fact]
+    public void Non_positive_policy_distributed_expiration_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.Configure<InMemoryCacheOptions>(o => o.DefaultExpiration = null);
+                b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+            },
+            o => o.DefaultCachePolicy = new CachePolicy { DistributedExpiration = TimeSpan.FromSeconds(-1) });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*would expire immediately*");
+    }
+
+    /// <summary>
+    /// The multilayer tiers apply ICacheOptions.CacheKeyStrategy on top of the key the adapter composed, so an
+    /// application strategy configured on the tier must not transform these keys a second time.
+    /// </summary>
+    [Theory]
+    [InlineData(KnownCacheProviderNames.InMemory)]
+    [InlineData(KnownCacheProviderNames.InMemoryRedis)]
+    public void Application_tier_key_strategy_does_not_reach_the_distributed_keys(string providerName)
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddInMemoryRedis(o => o.CacheKeyStrategy = new LowercasingCacheKeyStrategy());
+                b.AddMemory(o => o.CacheKeyStrategy = new LowercasingCacheKeyStrategy());
+                b.AddDistributedCache(providerName);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        cache.Set("AbC", [1], new DistributedCacheEntryOptions());
+
+        // A strategy that lowercased these keys would make the two spellings one entry.
+        cache.Get("abc").Should().BeNull();
+    }
+
+    private sealed class LowercasingCacheKeyStrategy : ICacheKeyStrategy
+    {
+        public CacheKey GetCacheKey<T>(CacheKey key) => new(key.Name, CacheKeyCasing.Insensitive);
+    }
+
+    /// <summary>Registration-time, not resolve-time: a typo must not survive until the first cache hit.</summary>
+    [Fact]
+    public void Redis_key_differentiator_is_validated_before_the_container_is_built()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddCaching(b => b.AddDistributedCache(
+            KnownCacheProviderNames.Redis, o => o.RedisKeyDifferentiator = RedisTypePrefixes.Hash));
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/tests/UiPath.Caching.Tests/Config/KeyCasingOptionsTests.cs
+++ b/tests/UiPath.Caching.Tests/Config/KeyCasingOptionsTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using UiPath.Caching.Config;
+
+namespace UiPath.Caching.Tests.Config;
+
+[CollectionDefinition("CacheKeyDefaultCasing", DisableParallelization = true)]
+public class CacheKeyDefaultCasingCollection;
+
+[Collection("CacheKeyDefaultCasing")]
+public class KeyCasingOptionsTests
+{
+    /// <summary>
+    /// The section-only overload must bind <see cref="CacheOptions"/>; passing the binder positionally made it
+    /// land on the builder parameter, leaving the section unread and the casing silently at its default.
+    /// </summary>
+    [Fact]
+    public void Section_only_overload_binds_key_casing()
+    {
+        try
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["Caching:KeyCasing"] = nameof(CacheKeyCasing.Sensitive) })
+                .Build();
+            var services = new ServiceCollection();
+
+            services.AddCaching(configuration.GetSection("Caching"));
+            using var provider = services.BuildServiceProvider();
+
+            provider.GetRequiredService<IOptions<CacheOptions>>().Value.KeyCasing
+                .Should().Be(CacheKeyCasing.Sensitive);
+            CacheKey.DefaultCasing.Should().Be(CacheKeyCasing.Sensitive);
+        }
+        finally
+        {
+            CacheKey.DefaultCasing = CacheKeyCasing.Insensitive;
+        }
+    }
+
+    /// <summary>
+    /// Configuration binds enums numerically without validating them, and treating an unknown value as
+    /// sensitive would silently stop lowercasing and relocate every key.
+    /// </summary>
+    [Fact]
+    public void Unsupported_key_casing_value_fails_fast()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddCaching(_ => { }, o => o.KeyCasing = (CacheKeyCasing)2);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*KeyCasing*unsupported value 2*");
+    }
+
+    /// <summary>
+    /// Options registered after AddCaching bypass the eager seed and reach only the PostConfigure callback, so
+    /// that callback validates too — otherwise resolving options succeeds and the next key built throws.
+    /// </summary>
+    [Fact]
+    public void Unsupported_key_casing_configured_after_AddCaching_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(_ => { });
+        services.Configure<CacheOptions>(o => o.KeyCasing = (CacheKeyCasing)3);
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*KeyCasing*unsupported value 3*");
+    }
+
+    /// <summary>
+    /// Post-configure callbacks run in registration order, so seeding from one would leave the global default
+    /// at whatever was seeded first while the resolved options reported the consumer's later value.
+    /// </summary>
+    [Fact]
+    public void Casing_post_configured_after_AddCaching_still_reaches_the_global_default()
+    {
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddCaching(_ => { }, o => o.KeyCasing = CacheKeyCasing.Insensitive);
+            services.PostConfigure<CacheOptions>(o => o.KeyCasing = CacheKeyCasing.Sensitive);
+            using var provider = services.BuildServiceProvider();
+
+            provider.GetRequiredService<IOptions<CacheOptions>>().Value.KeyCasing
+                .Should().Be(CacheKeyCasing.Sensitive);
+            CacheKey.DefaultCasing.Should().Be(CacheKeyCasing.Sensitive);
+            new CacheKey("AbC").Name.Should().Be("AbC");
+        }
+        finally
+        {
+            CacheKey.DefaultCasing = CacheKeyCasing.Insensitive;
+        }
+    }
+
+    /// <summary>The global default is state every key reads, so a bad value is refused where it is assigned.</summary>
+    [Fact]
+    public void Unsupported_default_casing_is_rejected_by_the_setter()
+    {
+        var act = () => CacheKey.DefaultCasing = (CacheKeyCasing)2;
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+        CacheKey.DefaultCasing.Should().Be(CacheKeyCasing.Insensitive, "the assignment was refused");
+    }
+
+    /// <summary>Same guarantee at the key itself, for a casing value that never passed through the options.</summary>
+    [Fact]
+    public void Unsupported_key_casing_is_rejected_by_the_key()
+    {
+        var act = () => new CacheKey("AbC", (CacheKeyCasing)7);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Fact]
+    public void KeyCasing_defaults_to_insensitive()
+    {
+        new CacheOptions().KeyCasing.Should().Be(CacheKeyCasing.Insensitive);
+    }
+
+    [Fact]
+    public void Resolving_options_seeds_the_ambient_default()
+    {
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddCaching(_ => { }, o => o.KeyCasing = CacheKeyCasing.Sensitive);
+            using var provider = services.BuildServiceProvider();
+
+            _ = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            CacheKey.DefaultCasing.Should().Be(CacheKeyCasing.Sensitive);
+            new CacheKey("AbC").Name.Should().Be("AbC");
+        }
+        finally
+        {
+            CacheKey.DefaultCasing = CacheKeyCasing.Insensitive;
+        }
+    }
+
+    [Fact]
+    public void Insensitive_configuration_keeps_lowercasing()
+    {
+        try
+        {
+            var services = new ServiceCollection();
+            services.AddCaching(_ => { });
+            using var provider = services.BuildServiceProvider();
+            _ = provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+            CacheKey.DefaultCasing.Should().Be(CacheKeyCasing.Insensitive);
+            new CacheKey("AbC").Name.Should().Be("abc");
+        }
+        finally
+        {
+            CacheKey.DefaultCasing = CacheKeyCasing.Insensitive;
+        }
+    }
+}

--- a/tests/UiPath.Caching.Tests/Distributed/DistributedCacheEndToEndTests.cs
+++ b/tests/UiPath.Caching.Tests/Distributed/DistributedCacheEndToEndTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Internal;
+using UiPath.Caching.Config;
+
+namespace UiPath.Caching.Tests.Distributed;
+
+[Collection("CacheKeyDefaultCasing")]   // mutates CacheKey.DefaultCasing — serialized collection
+public class DistributedCacheEndToEndTests
+{
+    /// <summary>
+    /// Drives both the adapter and the backing memory cache, so expiration can be advanced
+    /// deterministically instead of racing the wall clock.
+    /// </summary>
+    private sealed class FakeClock(DateTimeOffset now) : ISystemClock
+    {
+        public DateTimeOffset UtcNow { get; private set; } = now;
+
+        public void Advance(TimeSpan delta) => UtcNow = UtcNow.Add(delta);
+    }
+
+    private static readonly DateTimeOffset Start = new(2026, 8, 19, 12, 0, 0, TimeSpan.Zero);
+
+    private static ServiceProvider Build(FakeClock clock)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ISystemClock>(clock);
+        services.AddCaching(b =>
+        {
+            b.AddMemory(o => o.Clock = clock);
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+        });
+        return services.BuildServiceProvider();
+    }
+
+    /// <summary>Each touch falls inside the sliding window, so the entry survives well past one window — until the absolute cap passes.</summary>
+    [Fact]
+    public async Task Session_scenario_idle_keeps_alive_and_absolute_cap_wins()
+    {
+        var clock = new FakeClock(Start);
+        using var provider = Build(clock);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+        var token = TestContext.Current.CancellationToken;
+
+        await cache.SetAsync("Session-AbC", [1], new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(20),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(2),
+        }, token);
+
+        for (var i = 0; i < 4; i++)
+        {
+            clock.Advance(TimeSpan.FromMinutes(15));
+            (await cache.GetAsync("Session-AbC", token)).Should().NotBeNull("touch {0} slides the window", i);
+        }
+
+        clock.Advance(TimeSpan.FromHours(2));
+        (await cache.GetAsync("Session-AbC", token)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Refresh_extends_without_reading_data()
+    {
+        var clock = new FakeClock(Start);
+        using var provider = Build(clock);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+        var token = TestContext.Current.CancellationToken;
+
+        await cache.SetAsync("k", [1], new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(10) }, token);
+
+        clock.Advance(TimeSpan.FromMinutes(8));
+        await cache.RefreshAsync("k", token);
+        clock.Advance(TimeSpan.FromMinutes(8));   // 16 min total — gone without the refresh
+
+        (await cache.GetAsync("k", token)).Should().NotBeNull();
+    }
+
+    /// <summary>Flipping the ambient default must not change how the adapter keys anything.</summary>
+    [Fact]
+    public async Task Global_key_casing_does_not_move_distributed_keys()
+    {
+        try
+        {
+            var clock = new FakeClock(Start);
+            using var provider = Build(clock);
+            var cache = provider.GetRequiredService<IDistributedCache>();
+            var token = TestContext.Current.CancellationToken;
+
+            CacheKey.DefaultCasing = CacheKeyCasing.Insensitive;
+            await cache.SetAsync("AbC", [1], new DistributedCacheEntryOptions(), token);
+
+            CacheKey.DefaultCasing = CacheKeyCasing.Sensitive;
+            (await cache.GetAsync("AbC", token)).Should().Equal(1);
+            (await cache.GetAsync("abc", token)).Should().BeNull();
+        }
+        finally
+        {
+            CacheKey.DefaultCasing = CacheKeyCasing.Insensitive;
+        }
+    }
+
+    /// <summary>Documented deviation: <see cref="CacheKey"/> trims, so " k " and "k" are one key.</summary>
+    [Fact]
+    public async Task Whitespace_wrapped_keys_collide_by_design()
+    {
+        var clock = new FakeClock(Start);
+        using var provider = Build(clock);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+        var token = TestContext.Current.CancellationToken;
+
+        await cache.SetAsync(" k ", [1], new DistributedCacheEntryOptions(), token);
+        (await cache.GetAsync("k", token)).Should().Equal(1);
+    }
+}

--- a/tests/UiPath.Caching.Tests/Distributed/DistributedCacheRedisIntegrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Distributed/DistributedCacheRedisIntegrationTests.cs
@@ -1,0 +1,177 @@
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using StackExchange.Redis;
+using UiPath.Caching.Config;
+using UiPath.Caching.Distributed;
+using UiPath.Caching.Redis;
+using UiPath.Caching.Tests.Redis;
+
+namespace UiPath.Caching.Tests.Distributed;
+
+/// <summary>
+/// Exercises the recommended tier against a real Redis. The other adapter tests substitute
+/// <see cref="IHashCache"/> or run on the InMemory tier, so the hash wire layout, the physical keyspace and
+/// metadata-only refresh are only verified here — through StackExchange.Redis, as deployments use it.
+/// </summary>
+[Collection("RedisIntegration")]
+[Trait("Category", "Integration")]
+public class DistributedCacheRedisIntegrationTests(RedisContainerFixture fixture)
+{
+    private const string AppShortName = "dcit";
+
+    private static ServiceProvider Build(string connectionString) =>
+        new ServiceCollection()
+            .AddCaching(
+                b =>
+                {
+                    b.AddRedisConnection(o => o.ConnectionString = connectionString);
+                    b.AddRedis(_ => { });
+                    b.AddDistributedCache(KnownCacheProviderNames.Redis);
+                },
+                o => o.AppShortName = AppShortName)
+            .BuildServiceProvider();
+
+    private static string Unique() => $"it-{Guid.NewGuid():N}";
+
+    private Task<ConnectionMultiplexer> ConnectAsync() =>
+        ConnectionMultiplexer.ConnectAsync(fixture.ConnectionString);
+
+    [Fact]
+    public async Task Round_trips_a_payload_through_redis()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+        var token = TestContext.Current.CancellationToken;
+        var key = Unique();
+        using var provider = Build(fixture.ConnectionString);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        await cache.SetAsync(key, [1, 2, 3], new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(10),
+        }, token);
+
+        (await cache.GetAsync(key, token)).Should().Equal(1, 2, 3);
+        (await cache.GetAsync(key.ToUpperInvariant(), token)).Should().BeNull("keys are case-sensitive");
+
+        await cache.RemoveAsync(key, token);
+        (await cache.GetAsync(key, token)).Should().BeNull();
+    }
+
+    /// <summary>The wire layout: a hash with the payload raw and the two expiration fields beside it.</summary>
+    [Fact]
+    public async Task Stores_a_hash_with_the_documented_fields_in_its_own_keyspace()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+        var token = TestContext.Current.CancellationToken;
+        var key = Unique();
+        using var provider = Build(fixture.ConnectionString);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+        await using var multiplexer = await ConnectAsync();
+        var database = multiplexer.GetDatabase();
+
+        await cache.SetAsync(key, [7, 8], new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(20),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(2),
+        }, token);
+
+        var redisKey = $"{AppShortName}:{UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator}:{UiPathDistributedCacheOptions.DefaultKeyPrefix}:{key}";
+        (await database.KeyTypeAsync(redisKey)).Should().Be(RedisType.Hash);
+        (await database.HashGetAsync(redisKey, "data")).Should().Be((RedisValue)new byte[] { 7, 8 });
+        ((long?)await database.HashGetAsync(redisKey, "sldexp")).Should().Be(TimeSpan.FromMinutes(20).Ticks);
+        ((long?)await database.HashGetAsync(redisKey, "absexp")).Should().BePositive();
+        (await database.KeyTimeToLiveAsync(redisKey)).Should().NotBeNull();
+
+        // Nothing lands in the application's own hash keyspace.
+        var applicationKey = $"{AppShortName}:{RedisTypePrefixes.Hash}:{key}";
+        (await database.KeyExistsAsync(applicationKey)).Should().BeFalse();
+
+        await cache.RemoveAsync(key, token);
+        (await database.KeyExistsAsync(redisKey)).Should().BeFalse();
+    }
+
+    /// <summary>An empty payload is a hit, not a miss — the field is stored zero-length and read back as such.</summary>
+    [Fact]
+    public async Task Empty_payload_round_trips_as_empty()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+        var token = TestContext.Current.CancellationToken;
+        var key = Unique();
+        using var provider = Build(fixture.ConnectionString);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+
+        await cache.SetAsync(key, [], new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(5),
+        }, token);
+
+        (await cache.GetAsync(key, token)).Should().NotBeNull().And.BeEmpty();
+
+        await cache.RemoveAsync(key, token);
+    }
+
+    /// <summary>Refresh extends the TTL without transferring the payload, and the absolute deadline still caps it.</summary>
+    [Fact]
+    public async Task Refresh_extends_the_ttl_and_the_absolute_deadline_caps_it()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+        var token = TestContext.Current.CancellationToken;
+        var key = Unique();
+        using var provider = Build(fixture.ConnectionString);
+        var cache = provider.GetRequiredService<IDistributedCache>();
+        await using var multiplexer = await ConnectAsync();
+        var database = multiplexer.GetDatabase();
+        var redisKey = $"{AppShortName}:{UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator}:{UiPathDistributedCacheOptions.DefaultKeyPrefix}:{key}";
+
+        await cache.SetAsync(key, [1], new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(30),
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(45),
+        }, token);
+
+        await database.KeyExpireAsync(redisKey, TimeSpan.FromMinutes(5));
+        (await database.KeyTimeToLiveAsync(redisKey)).Should().BeCloseTo(TimeSpan.FromMinutes(5), TimeSpan.FromSeconds(30));
+
+        await cache.RefreshAsync(key, token);
+
+        var afterRefresh = await database.KeyTimeToLiveAsync(redisKey);
+        afterRefresh.Should().NotBeNull();
+        afterRefresh!.Value.Should().BeGreaterThan(TimeSpan.FromMinutes(10), "the sliding window was reapplied");
+        afterRefresh.Value.Should().BeLessThan(TimeSpan.FromMinutes(46), "the absolute deadline caps the slide");
+
+        await cache.RemoveAsync(key, token);
+    }
+
+    /// <summary>
+    /// The provider sets <see cref="RedisCacheOptions.AwaitRefresh"/>, so the extension is in effect when the
+    /// call returns and the result reports whether it applied — neither is true fire-and-forget.
+    /// </summary>
+    [Fact]
+    public async Task Refresh_is_applied_and_reported_before_it_returns()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+        var token = TestContext.Current.CancellationToken;
+        var key = Unique();
+        using var provider = Build(fixture.ConnectionString);
+        var hash = provider.GetRequiredKeyedService<IHashCache>(
+            DistributedCacheCollectionExtensions.DistributedCacheServiceKey);
+        var cacheKey = new CacheKey($"{UiPathDistributedCacheOptions.DefaultKeyPrefix}:{key}", CacheKeyCasing.Sensitive);
+        await using var multiplexer = await ConnectAsync();
+        var database = multiplexer.GetDatabase();
+        var redisKey = $"{AppShortName}:{UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator}:{cacheKey.Name}";
+
+        await hash.SetAsync(cacheKey, new Dictionary<string, byte[]?> { ["data"] = [1] }, TimeSpan.FromMinutes(5), null, token);
+
+        var applied = await hash.RefreshAsync<byte[]>(cacheKey, (DateTimeOffset?)DateTimeOffset.UtcNow.AddMinutes(30), null, token);
+
+        applied.Should().BeTrue("the reply is observed, so the result is meaningful");
+        (await database.KeyTimeToLiveAsync(redisKey)).Should()
+            .BeGreaterThan(TimeSpan.FromMinutes(10), "no polling needed once the reply is awaited");
+
+        var absent = new CacheKey($"{UiPathDistributedCacheOptions.DefaultKeyPrefix}:{Unique()}", CacheKeyCasing.Sensitive);
+        (await hash.RefreshAsync<byte[]>(absent, (DateTimeOffset?)DateTimeOffset.UtcNow.AddMinutes(30), null, token))
+            .Should().BeFalse("a missing key is now distinguishable from a hit");
+
+        await hash.RemoveAsync<byte[]>(cacheKey, token);
+    }
+}

--- a/tests/UiPath.Caching.Tests/Distributed/RedisValueSerializerProxyTests.cs
+++ b/tests/UiPath.Caching.Tests/Distributed/RedisValueSerializerProxyTests.cs
@@ -1,0 +1,44 @@
+using StackExchange.Redis;
+using UiPath.Caching.Distributed;
+
+namespace UiPath.Caching.Tests.Distributed;
+
+public class RedisValueSerializerProxyTests
+{
+    private sealed record Poco(string Name);
+
+    private readonly RedisValueSerializerProxy _proxy = new(new SystemJsonByteSerializerProxy());
+
+    [Fact]
+    public void Bytes_round_trip_unencoded()
+    {
+        var payload = new byte[] { 0x00, 0x01, 0xFF };
+        RedisValue stored = _proxy.Serialize(payload);
+        ((byte[])stored!).Should().Equal(payload);
+        _proxy.Deserialize<byte[]>(stored).Should().Equal(payload);
+    }
+
+    [Fact]
+    public void Null_and_empty_map_to_defaults()
+    {
+        _proxy.Serialize(null).IsNull.Should().BeTrue();
+        _proxy.Deserialize<Poco>(RedisValue.Null).Should().BeNull();
+        _proxy.Deserialize<Poco>(RedisValue.EmptyString).Should().BeNull();
+    }
+
+    [Fact]
+    public void Poco_round_trips_via_inner_json()
+    {
+        var value = new Poco("x");
+        var stored = _proxy.Serialize(value);
+        _proxy.Deserialize<Poco>(stored).Should().Be(value);
+    }
+
+    [Fact]
+    public void TryDeserialize_delegates_to_inner()
+    {
+        _proxy.TryDeserialize<Poco>("""{"Name":"x"}""", out var ok).Should().BeTrue();
+        ok.Should().Be(new Poco("x"));
+        _proxy.TryDeserialize<Poco>("not json", out _).Should().BeFalse();
+    }
+}

--- a/tests/UiPath.Caching.Tests/Distributed/UiPathDistributedCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/Distributed/UiPathDistributedCacheTests.cs
@@ -1,0 +1,658 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using UiPath.Caching.Config;
+using UiPath.Caching.Distributed;
+
+namespace UiPath.Caching.Tests.Distributed;
+
+public class UiPathDistributedCacheTests
+{
+    private const string DataField = "data";
+    private const string AbsoluteExpirationField = "absexp";
+    private const string SlidingExpirationField = "sldexp";
+
+    private static readonly DateTimeOffset Now = new(2026, 8, 13, 10, 0, 0, TimeSpan.Zero);
+    private static readonly byte[] Payload = [1, 2, 3];
+
+    private readonly IHashCache _inner = Substitute.For<IHashCache>();
+    private readonly ISystemClock _clock = Substitute.For<ISystemClock>();
+    private readonly UiPathDistributedCache _cache;
+
+    public UiPathDistributedCacheTests()
+    {
+        _clock.UtcNow.Returns(Now);
+        _cache = Build();
+    }
+
+    private UiPathDistributedCache Build(
+        UiPathDistributedCacheOptions? options = null,
+        bool slideByRewrite = false,
+        ICacheKeyStrategy? keyStrategy = null) =>
+        new(_inner,
+            options ?? new UiPathDistributedCacheOptions(),
+            keyStrategy ?? new PrefixCacheKeyStrategy(UiPathDistributedCacheOptions.DefaultKeyPrefix),
+            policy: null,
+            NullLogger.Instance,
+            _clock,
+            slideByRewrite);
+
+    private static byte[] Ticks(long? value) =>
+        Encoding.UTF8.GetBytes((value ?? -1).ToString(CultureInfo.InvariantCulture));
+
+    private static Dictionary<string, byte[]?> Entry(long? slidingTicks = null, DateTimeOffset? absolute = null) => new()
+    {
+        [DataField] = Payload,
+        [AbsoluteExpirationField] = Ticks(absolute?.UtcTicks),
+        [SlidingExpirationField] = Ticks(slidingTicks),
+    };
+
+    private void StoredEntry(Dictionary<string, byte[]?> fields) =>
+        _inner.GetAsync<byte[]>(Arg.Any<CacheKey>(), Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>())
+            .Returns(fields);
+
+
+    /// <summary>
+    /// The storage key the default strategy produces. Tests whose subject is not the key's shape go
+    /// through this, so "prefix plus separator" is asserted in one place — as the default, not as the
+    /// contract — rather than restated in every expectation.
+    /// </summary>
+    private static string Key(string callerKey) =>
+        new PrefixCacheKeyStrategy(UiPathDistributedCacheOptions.DefaultKeyPrefix)
+            .GetCacheKey<byte[]>(new CacheKey(callerKey, CacheKeyCasing.Sensitive)).Name;
+
+    /// <summary>Pinned literally, because changing the default relocates every stored entry.</summary>
+    [Fact]
+    public async Task Default_key_composition_is_pinned()
+    {
+        StoredEntry(Entry());
+        await _cache.GetAsync("AbC-9xQ", TestContext.Current.CancellationToken);
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == "d:AbC-9xQ"),
+            Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Keys_are_case_sensitive_and_preserved()
+    {
+        StoredEntry(Entry());
+        var expected = Key("AbC-9xQ");
+        await _cache.GetAsync("AbC-9xQ", TestContext.Current.CancellationToken);
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == expected && k.Casing == CacheKeyCasing.Sensitive),
+            Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The application's own <see cref="IHashCache"/> asking for the caller key must never land on these entries.</summary>
+    [Fact]
+    public async Task Composed_key_keeps_the_bare_caller_key_unreachable()
+    {
+        StoredEntry(Entry());
+        var token = TestContext.Current.CancellationToken;
+        var expected = Key("AbC");
+
+        await _cache.GetAsync("AbC", token);
+        await _cache.SetAsync("AbC", Payload, new DistributedCacheEntryOptions(), token);
+        await _cache.RemoveAsync("AbC", token);
+
+        expected.Should().NotBe("AbC");
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == expected),
+            Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        await _inner.Received(1).SetAsync(
+            Arg.Is<CacheKey>(k => k.Name == expected),
+            Arg.Any<IDictionary<string, byte[]?>>(), Arg.Any<TimeSpan?>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        await _inner.Received(1).RemoveAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == expected), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Custom_key_strategy_replaces_the_default()
+    {
+        StoredEntry(Entry());
+        var custom = Build(keyStrategy: new PrefixCacheKeyStrategy("mine", '/'));
+        await custom.GetAsync("AbC", TestContext.Current.CancellationToken);
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == "mine/AbC" && k.Casing == CacheKeyCasing.Sensitive),
+            Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>The seam only transforms the key, so nothing downstream assumes where the marker sits.</summary>
+    [Fact]
+    public async Task Key_strategy_need_not_be_a_prefix()
+    {
+        StoredEntry(Entry());
+        var suffixed = Build(keyStrategy: new SuffixKeyStrategy(":d"));
+        await suffixed.GetAsync("AbC", TestContext.Current.CancellationToken);
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == "AbC:d" && k.Casing == CacheKeyCasing.Sensitive),
+            Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Default_cache_key_strategy_stores_the_bare_key()
+    {
+        StoredEntry(Entry());
+        var bare = Build(keyStrategy: new DefaultCacheKeyStrategy());
+        await bare.GetAsync("AbC", TestContext.Current.CancellationToken);
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == "AbC"),
+            Arg.Any<string[]>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Key_strategy_returning_an_empty_key_fails_loudly()
+    {
+        var broken = Build(keyStrategy: new EmptyKeyStrategy());
+        (await FluentActions.Awaiting(() => broken.GetAsync("k", TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<InvalidOperationException>()).WithMessage("*CacheKeyStrategy*empty key*");
+    }
+
+    /// <summary>
+    /// A strategy rebuilding the key instead of using <see cref="CacheKey.WithName"/> picks up the ambient
+    /// casing, which would lowercase a case-significant caller key with the original spelling already lost.
+    /// </summary>
+    [Fact]
+    public async Task Key_strategy_dropping_case_sensitivity_fails_loudly()
+    {
+        var lossy = Build(keyStrategy: new AmbientCasingKeyStrategy());
+        (await FluentActions.Awaiting(() => lossy.GetAsync("AbC", TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<InvalidOperationException>()).WithMessage("*case-significant*WithName*");
+    }
+
+    private sealed class SuffixKeyStrategy(string suffix) : ICacheKeyStrategy
+    {
+        public CacheKey GetCacheKey<T>(CacheKey key) => key.WithName(key.Name + suffix);
+    }
+
+    private sealed class AmbientCasingKeyStrategy : ICacheKeyStrategy
+    {
+        public CacheKey GetCacheKey<T>(CacheKey key) => new(key.Name, CacheKeyCasing.Insensitive);
+    }
+
+    private sealed class EmptyKeyStrategy : ICacheKeyStrategy
+    {
+        public CacheKey GetCacheKey<T>(CacheKey key) => default;
+    }
+
+    [Fact]
+    public async Task Null_key_throws()
+    {
+        await FluentActions.Awaiting(() => _cache.GetAsync(null!, TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    [Fact]
+    public async Task Whitespace_only_key_throws_argument_exception()
+    {
+        (await FluentActions.Awaiting(() => _cache.GetAsync("   ", TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<ArgumentException>()).And.Should().NotBeOfType<ArgumentNullException>();
+    }
+
+    /// <summary>A failed write has to name the entry, or the message cannot be acted on.</summary>
+    [Fact]
+    public async Task Failed_write_logs_the_key()
+    {
+        const string key = "Session-AbC";
+        var logger = new CapturingLogger();
+        var cache = new UiPathDistributedCache(
+            _inner, new UiPathDistributedCacheOptions(),
+            new PrefixCacheKeyStrategy(UiPathDistributedCacheOptions.DefaultKeyPrefix),
+            policy: null, logger, _clock);
+        _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Any<TimeSpan?>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>()).Returns(false);
+
+        await cache.SetAsync(key, Payload, new DistributedCacheEntryOptions(), TestContext.Current.CancellationToken);
+
+        logger.Messages.Should().ContainSingle().Which.Should().Contain(key);
+    }
+
+    private sealed class CapturingLogger : ILogger
+    {
+        public List<string> Messages { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter) =>
+            Messages.Add(formatter(state, exception));
+    }
+
+    /// <summary>The prefix the strategy adds must not make an empty caller key look valid.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Empty_caller_key_throws(string key)
+    {
+        await FluentActions.Awaiting(() => _cache.GetAsync(key, TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<ArgumentException>();
+    }
+
+
+    [Fact]
+    public async Task Get_miss_returns_null()
+    {
+        StoredEntry([]);
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Get_returns_payload_and_slides_when_sliding_set()
+    {
+        var sliding = TimeSpan.FromMinutes(20);
+        StoredEntry(Entry(sliding.Ticks));
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().Equal(Payload);
+
+        await _inner.Received(1).RefreshAsync<byte[]>(
+            Arg.Any<CacheKey>(), (DateTimeOffset?)Now.Add(sliding), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_requests_all_fields_including_data()
+    {
+        StoredEntry(Entry());
+        await _cache.GetAsync("k", TestContext.Current.CancellationToken);
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Any<CacheKey>(), Arg.Is<string[]>(f => f != null && f.Contains(DataField)),
+            Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_slide_is_capped_by_absolute_expiration()
+    {
+        var absolute = Now.AddMinutes(5);
+        StoredEntry(Entry(TimeSpan.FromMinutes(20).Ticks, absolute));
+
+        await _cache.GetAsync("k", TestContext.Current.CancellationToken);
+
+        await _inner.Received(1).RefreshAsync<byte[]>(
+            Arg.Any<CacheKey>(), (DateTimeOffset?)absolute, Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Get_without_sliding_does_not_refresh()
+    {
+        StoredEntry(Entry(absolute: Now.AddHours(1)));
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().Equal(Payload);
+
+        await _inner.DidNotReceiveWithAnyArgs().RefreshAsync<byte[]>(default, (DateTimeOffset?)null, null, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task Absurd_sliding_window_clamps_instead_of_overflowing()
+    {
+        StoredEntry(Entry(long.MaxValue));
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().Equal(Payload);
+
+        await _inner.Received(1).RefreshAsync<byte[]>(
+            Arg.Any<CacheKey>(), (DateTimeOffset?)DateTimeOffset.MaxValue, Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Unrecognized_entry_is_a_miss()
+    {
+        StoredEntry(new Dictionary<string, byte[]?> { ["something-else"] = [9] });
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Expired_absolute_entry_is_a_miss_and_is_not_removed()
+    {
+        StoredEntry(Entry(TimeSpan.FromMinutes(20).Ticks, Now.AddMinutes(-1)));
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().BeNull();
+
+        await _inner.DidNotReceiveWithAnyArgs().RemoveAsync<byte[]>(default, TestContext.Current.CancellationToken);
+        await _inner.DidNotReceiveWithAnyArgs().RefreshAsync<byte[]>(default, (DateTimeOffset?)null, null, TestContext.Current.CancellationToken);
+    }
+
+
+    [Fact]
+    public async Task Set_writes_payload_and_metadata_fields()
+    {
+        var sliding = TimeSpan.FromMinutes(20);
+        IDictionary<string, byte[]?>? written = null;
+        TimeSpan? ttl = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Do<IDictionary<string, byte[]?>>(v => written = v),
+            Arg.Do<TimeSpan?>(t => ttl = t), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+
+        await _cache.SetAsync("k", Payload, new DistributedCacheEntryOptions { SlidingExpiration = sliding }, TestContext.Current.CancellationToken);
+
+        ttl.Should().Be(sliding);
+        written.Should().NotBeNull();
+        written![DataField].Should().Equal(Payload);
+        Encoding.UTF8.GetString(written[SlidingExpirationField]!).Should().Be(sliding.Ticks.ToString(CultureInfo.InvariantCulture));
+        Encoding.UTF8.GetString(written[AbsoluteExpirationField]!).Should().Be("-1");
+    }
+
+    [Fact]
+    public async Task Set_with_both_uses_min_of_sliding_and_remaining_absolute()
+    {
+        TimeSpan? ttl = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Do<TimeSpan?>(t => ttl = t), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+
+        await _cache.SetAsync("k", Payload, new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = TimeSpan.FromMinutes(20),
+            AbsoluteExpiration = Now.AddMinutes(5),
+        }, TestContext.Current.CancellationToken);
+
+        ttl.Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public async Task Set_with_relative_absolute_records_the_deadline()
+    {
+        IDictionary<string, byte[]?>? written = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Do<IDictionary<string, byte[]?>>(v => written = v),
+            Arg.Any<TimeSpan?>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+
+        await _cache.SetAsync("k", Payload, new DistributedCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(30),
+        }, TestContext.Current.CancellationToken);
+
+        Encoding.UTF8.GetString(written![AbsoluteExpirationField]!)
+            .Should().Be(Now.AddMinutes(30).UtcTicks.ToString(CultureInfo.InvariantCulture));
+    }
+
+    [Fact]
+    public async Task Set_with_no_expiration_uses_the_configured_default()
+    {
+        TimeSpan? ttl = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Do<TimeSpan?>(t => ttl = t), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        var bounded = Build(new UiPathDistributedCacheOptions { DefaultEntryExpiration = TimeSpan.FromHours(2) });
+
+        await bounded.SetAsync("k", Payload, new DistributedCacheEntryOptions(), TestContext.Current.CancellationToken);
+
+        ttl.Should().Be(TimeSpan.FromHours(2));
+    }
+
+    [Fact]
+    public async Task Set_with_no_expiration_and_no_default_defers_to_the_tier()
+    {
+        TimeSpan? ttl = TimeSpan.FromDays(999);
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Do<TimeSpan?>(t => ttl = t), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+
+        await _cache.SetAsync("k", Payload, new DistributedCacheEntryOptions(), TestContext.Current.CancellationToken);
+
+        ttl.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Set_with_past_absolute_expiration_throws()
+    {
+        await FluentActions.Awaiting(() => _cache.SetAsync("k", Payload,
+                new DistributedCacheEntryOptions { AbsoluteExpiration = Now.AddMinutes(-1) }, TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<ArgumentOutOfRangeException>();
+    }
+
+
+    [Fact]
+    public async Task Refresh_reads_metadata_only()
+    {
+        var sliding = TimeSpan.FromMinutes(20);
+        StoredEntry(Entry(sliding.Ticks));
+
+        await _cache.RefreshAsync("k", TestContext.Current.CancellationToken);
+
+        await _inner.Received(1).GetAsync<byte[]>(
+            Arg.Any<CacheKey>(), Arg.Is<string[]>(f => f != null && !f.Contains(DataField)),
+            Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        await _inner.Received(1).RefreshAsync<byte[]>(
+            Arg.Any<CacheKey>(), (DateTimeOffset?)Now.Add(sliding), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Remove_forwards()
+    {
+        var expected = Key("AbC");
+        await _cache.RemoveAsync("AbC", TestContext.Current.CancellationToken);
+        await _inner.Received(1).RemoveAsync<byte[]>(
+            Arg.Is<CacheKey>(k => k.Name == expected), Arg.Any<CancellationToken>());
+    }
+
+
+    [Fact]
+    public async Task SlideByRewrite_extends_by_writing_the_entry_back()
+    {
+        var sliding = TimeSpan.FromMinutes(20);
+        StoredEntry(Entry(sliding.Ticks));
+        IDictionary<string, byte[]?>? written = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Do<IDictionary<string, byte[]?>>(v => written = v),
+            Arg.Any<HashCacheEntryOptions>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        var rewriting = Build(slideByRewrite: true);
+
+        (await rewriting.GetAsync("k", TestContext.Current.CancellationToken)).Should().Equal(Payload);
+
+        written.Should().NotBeNull();
+        written!.Should().ContainKey(SlidingExpirationField);
+        written[DataField].Should().Equal(Payload);
+        await _inner.DidNotReceiveWithAnyArgs().RefreshAsync<byte[]>(default, (DateTimeOffset?)null, null, TestContext.Current.CancellationToken);
+    }
+
+
+    [Fact]
+    public void Sync_methods_block_on_async()
+    {
+        StoredEntry(Entry());
+        _cache.Get("k").Should().Equal(Payload);
+    }
+
+    [Fact]
+    public async Task Unbounded_entries_persist_instead_of_taking_a_default()
+    {
+        DateTimeOffset? expiration = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Do<DateTimeOffset?>(e => expiration = e), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        var unbounded = Build(new UiPathDistributedCacheOptions { AllowUnboundedEntries = true });
+
+        await unbounded.SetAsync("k", Payload, new DistributedCacheEntryOptions(), TestContext.Current.CancellationToken);
+
+        expiration.Should().Be(DateTimeOffset.MaxValue);
+    }
+
+    [Fact]
+    public async Task Absurd_sliding_write_clamps_the_ttl()
+    {
+        TimeSpan? ttl = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Do<TimeSpan?>(t => ttl = t), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+
+        await _cache.SetAsync("k", Payload,
+            new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.MaxValue }, TestContext.Current.CancellationToken);
+
+        ttl.Should().NotBeNull();
+        // Against a later clock reading than the adapter's, which is what the backing cache actually adds to.
+        FluentActions.Invoking(() => Now.AddSeconds(30).Add(ttl!.Value)).Should().NotThrow();
+    }
+
+    /// <summary>
+    /// The hash layer reports a zero-length field as absent, so metadata presence is what distinguishes
+    /// "our entry with an empty payload" from "not our entry".
+    /// </summary>
+    [Fact]
+    public async Task Empty_payload_reads_back_as_empty_not_a_miss()
+    {
+        StoredEntry(new Dictionary<string, byte[]?>
+        {
+            [DataField] = null,
+            [AbsoluteExpirationField] = Ticks(null),
+            [SlidingExpirationField] = Ticks(null),
+        });
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Absurd_default_entry_expiration_is_clamped()
+    {
+        TimeSpan? ttl = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Any<IDictionary<string, byte[]?>>(),
+            Arg.Do<TimeSpan?>(t => ttl = t), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+        var cache = Build(new UiPathDistributedCacheOptions { DefaultEntryExpiration = TimeSpan.MaxValue });
+
+        await cache.SetAsync("k", Payload, new DistributedCacheEntryOptions(), TestContext.Current.CancellationToken);
+
+        ttl.Should().NotBeNull();
+        // Against a later clock reading than the adapter's, which is what the backing cache actually adds to.
+        FluentActions.Invoking(() => Now.AddSeconds(30).Add(ttl!.Value)).Should().NotThrow();
+    }
+
+    private const string FieldOmitted = "\0omitted";
+
+    /// <summary>
+    /// Values no write can produce, per field. Each is a miss: serving one would hand back the payload with its
+    /// expiration silently dropped — as an entry that never expires — which is the failure this decode exists to
+    /// prevent. Whitespace padding is included because the writer never emits it.
+    /// </summary>
+    public static TheoryData<string?> RejectedMetadataValues() =>
+    [
+        (string?)null,            // field present, null value — the shape a Redis miss returns
+        FieldOmitted,             // field absent entirely
+        "",
+        " ",
+        "garbage",
+        "1.5",
+        "1e3",
+        " 1 ",
+        "0",                      // parses, but is skipped downstream rather than applied
+        "-2",                     // not the sentinel
+        "9223372036854775808",    // one past long.MaxValue: does not parse
+    ];
+
+    [Theory]
+    [MemberData(nameof(RejectedMetadataValues))]
+    public async Task Rejected_absolute_expiration_is_a_miss(string? value) =>
+        await AssertMetadataIsRejected(AbsoluteExpirationField, value);
+
+    [Theory]
+    [MemberData(nameof(RejectedMetadataValues))]
+    public async Task Rejected_sliding_expiration_is_a_miss(string? value) =>
+        await AssertMetadataIsRejected(SlidingExpirationField, value);
+
+    private async Task AssertMetadataIsRejected(string field, string? value)
+    {
+        var entry = new Dictionary<string, byte[]?>(StringComparer.Ordinal)
+        {
+            [DataField] = Payload,
+            [AbsoluteExpirationField] = Ticks(null),
+            [SlidingExpirationField] = Ticks(null),
+        };
+
+        if (value == FieldOmitted)
+        {
+            entry.Remove(field);
+        }
+        else
+        {
+            entry[field] = value is null ? null : Encoding.UTF8.GetBytes(value);
+        }
+
+        StoredEntry(entry);
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+
+    /// <summary>
+    /// The two fields carry different quantities, so their ranges differ: an absolute deadline is a
+    /// <see cref="DateTime"/> tick count, a sliding window a <see cref="TimeSpan"/> one, which reaches further.
+    /// </summary>
+    [Fact]
+    public async Task Field_ranges_follow_the_quantity_each_field_carries()
+    {
+        var token = TestContext.Current.CancellationToken;
+        var beyondDateTime = Encoding.UTF8.GetBytes((DateTime.MaxValue.Ticks + 1).ToString(CultureInfo.InvariantCulture));
+
+        StoredEntry(new Dictionary<string, byte[]?>(StringComparer.Ordinal)
+        {
+            [DataField] = Payload,
+            [AbsoluteExpirationField] = beyondDateTime,
+            [SlidingExpirationField] = Ticks(null),
+        });
+        (await _cache.GetAsync("k", token)).Should().BeNull("an absolute deadline past DateTime.MaxValue cannot be decoded");
+
+        StoredEntry(new Dictionary<string, byte[]?>(StringComparer.Ordinal)
+        {
+            [DataField] = Payload,
+            [AbsoluteExpirationField] = Ticks(null),
+            [SlidingExpirationField] = beyondDateTime,
+        });
+        (await _cache.GetAsync("k", token)).Should().Equal(Payload, "the same number is a valid TimeSpan");
+    }
+
+    /// <summary>
+    /// The expiration shapes a caller can write, as serializable parts rather than a
+    /// <see cref="DistributedCacheEntryOptions"/> — the options type is not serializable, so passing it
+    /// directly leaves the runner unable to enumerate the rows individually.
+    /// </summary>
+    public static TheoryData<TimeSpan?, TimeSpan?, DateTimeOffset?> WriteShapes() => new()
+    {
+        { null, null, null },
+        { TimeSpan.FromMinutes(20), null, null },
+        { TimeSpan.FromTicks(1), null, null },
+        { TimeSpan.MaxValue, null, null },
+        { null, TimeSpan.FromHours(2), null },
+        { null, TimeSpan.MaxValue, null },
+        { null, null, Now.AddDays(1) },
+        { TimeSpan.FromMinutes(20), TimeSpan.FromHours(2), null },
+    };
+
+    /// <summary>
+    /// Whatever a write produces must decode as a hit. This is the property that keeps the accepted set and the
+    /// producible set in step: validating and decoding separately let the two rule sets drift, which is what
+    /// turned malformed metadata into a never-expiring entry.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(WriteShapes))]
+    public async Task Everything_a_write_produces_decodes_as_a_hit(
+        TimeSpan? slidingExpiration, TimeSpan? absoluteExpirationRelativeToNow, DateTimeOffset? absoluteExpiration)
+    {
+        var options = new DistributedCacheEntryOptions
+        {
+            SlidingExpiration = slidingExpiration,
+            AbsoluteExpirationRelativeToNow = absoluteExpirationRelativeToNow,
+            AbsoluteExpiration = absoluteExpiration,
+        };
+        var token = TestContext.Current.CancellationToken;
+        IDictionary<string, byte[]?>? written = null;
+        await _inner.SetAsync(Arg.Any<CacheKey>(), Arg.Do<IDictionary<string, byte[]?>>(v => written = v),
+            Arg.Any<TimeSpan?>(), Arg.Any<CachePolicy?>(), Arg.Any<CancellationToken>());
+
+        await _cache.SetAsync("k", Payload, options, token);
+
+        written.Should().NotBeNull();
+        StoredEntry(new Dictionary<string, byte[]?>(written!, StringComparer.Ordinal));
+
+        (await _cache.GetAsync("k", token)).Should().Equal(Payload);
+    }
+
+    /// <summary>
+    /// RedisHashCache returns a dictionary containing every requested field with null values when HMGET
+    /// finds nothing, so field presence alone cannot mean "entry exists".
+    /// </summary>
+    [Fact]
+    public async Task Redis_shaped_miss_is_a_miss_not_an_empty_payload()
+    {
+        StoredEntry(new Dictionary<string, byte[]?>
+        {
+            [DataField] = null,
+            [AbsoluteExpirationField] = null,
+            [SlidingExpirationField] = null,
+        });
+
+        (await _cache.GetAsync("k", TestContext.Current.CancellationToken)).Should().BeNull();
+    }
+}

--- a/tests/UiPath.Caching.Tests/PrefixCacheKeyStrategyTests.cs
+++ b/tests/UiPath.Caching.Tests/PrefixCacheKeyStrategyTests.cs
@@ -37,4 +37,24 @@ public class PrefixCacheKeyStrategyTests
         var actual = Sut.GetCacheKey<string>(cacheKey);
         actual.Should().Be((CacheKey)expected);
     }
+
+    [Fact]
+    public void Preserves_sensitive_casing_through_prefixing()
+    {
+        var strategy = new PrefixCacheKeyStrategy("MyApp");
+        var key = new CacheKey("AbC", CacheKeyCasing.Sensitive);
+
+        var result = strategy.GetCacheKey<string>(key);
+
+        result.Name.Should().Be("myapp:AbC");
+        result.Casing.Should().Be(CacheKeyCasing.Sensitive);
+    }
+
+    [Fact]
+    public void Insensitive_keys_behave_exactly_as_before()
+    {
+        var strategy = new PrefixCacheKeyStrategy("MyApp");
+        var result = strategy.GetCacheKey<string>(new CacheKey("AbC"));
+        result.Name.Should().Be("myapp:abc");
+    }
 }

--- a/tests/UiPath.Caching.Tests/SystemJsonByteSerializerProxyTests.cs
+++ b/tests/UiPath.Caching.Tests/SystemJsonByteSerializerProxyTests.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using System.Text.Json;
+
+namespace UiPath.Caching.Tests;
+
+public class SystemJsonByteSerializerProxyTests
+{
+    private readonly SystemJsonByteSerializerProxy _proxy = new();
+
+    private sealed record Poco(string Name, int Count);
+
+    [Fact]
+    public void Byte_array_passes_through_by_reference()
+    {
+        var payload = new byte[] { 0x00, 0x01, 0xFF };
+        _proxy.Serialize(payload).Should().BeSameAs(payload);
+        _proxy.Deserialize<byte[]>(payload).Should().BeSameAs(payload);
+    }
+
+    [Fact]
+    public void ReadOnlyMemory_is_materialized_not_json_encoded()
+    {
+        ReadOnlyMemory<byte> memory = new byte[] { 1, 2, 3 };
+        _proxy.Serialize(memory).Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void ReadOnlyMemory_round_trips()
+    {
+        ReadOnlyMemory<byte> memory = new byte[] { 1, 2, 3 };
+        var stored = _proxy.Serialize(memory);
+        _proxy.Deserialize<ReadOnlyMemory<byte>>(stored).ToArray().Should().Equal(1, 2, 3);
+    }
+
+    [Fact]
+    public void Empty_byte_array_round_trips()
+    {
+        var empty = Array.Empty<byte>();
+        _proxy.Serialize(empty).Should().BeSameAs(empty);
+        _proxy.Deserialize<byte[]>(empty).Should().BeSameAs(empty);
+    }
+
+    [Fact]
+    public void Null_maps_to_null_and_empty_to_default()
+    {
+        _proxy.Serialize(null).Should().BeNull();
+        _proxy.Deserialize<Poco>(null).Should().BeNull();
+        _proxy.Deserialize<Poco>([]).Should().BeNull();
+    }
+
+    [Fact]
+    public void Poco_round_trips_as_utf8_json()
+    {
+        var value = new Poco("x", 42);
+        var bytes = _proxy.Serialize(value)!;
+        JsonSerializer.Deserialize<Poco>(bytes).Should().Be(value);
+        _proxy.Deserialize<Poco>(bytes).Should().Be(value);
+    }
+
+    [Fact]
+    public void Deserializing_json_as_bytes_returns_raw_utf8()
+    {
+        var bytes = _proxy.Serialize(new Poco("x", 1))!;
+        _proxy.Deserialize<byte[]>(bytes).Should().BeSameAs(bytes);
+    }
+
+    [Fact]
+    public void TryDeserialize_string_success_and_failure()
+    {
+        _proxy.TryDeserialize<Poco>("""{"Name":"x","Count":1}""", out var ok).Should().BeTrue();
+        ok.Should().Be(new Poco("x", 1));
+        _proxy.TryDeserialize<Poco>("not json", out var bad).Should().BeFalse();
+        bad.Should().BeNull();
+        _proxy.TryDeserialize<Poco>("   ", out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void TryDeserialize_object_handles_bytes_json_element_and_text()
+    {
+        var raw = Encoding.UTF8.GetBytes("""{"Name":"x","Count":1}""");
+        _proxy.TryDeserialize<byte[]>(raw, out var bytes).Should().BeTrue();
+        bytes.Should().BeSameAs(raw);
+
+        var element = JsonSerializer.SerializeToElement(new Poco("x", 1));
+        _proxy.TryDeserialize<Poco>(element, out var fromElement).Should().BeTrue();
+        fromElement.Should().Be(new Poco("x", 1));
+
+        _proxy.TryDeserialize<Poco>((object)"""{"Name":"x","Count":1}""", out var fromText).Should().BeTrue();
+        fromText.Should().Be(new Poco("x", 1));
+
+        _proxy.TryDeserialize<Poco>(null, out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Honors_custom_serializer_options()
+    {
+        var proxy = new SystemJsonByteSerializerProxy(new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase });
+        Encoding.UTF8.GetString(proxy.Serialize(new Poco("x", 1))!).Should().Contain("\"name\"");
+    }
+
+    /// <summary><c>byte[]</c> is an object, so a naive "value is T" passthrough would hand back the raw bytes.</summary>
+    [Fact]
+    public void Deserializing_as_object_parses_json_instead_of_returning_bytes()
+    {
+        var bytes = _proxy.Serialize(new Poco("x", 1))!;
+
+        _proxy.Deserialize<object>(bytes).Should().NotBeOfType<byte[]>();
+    }
+
+    [Fact]
+    public void TryDeserialize_object_round_trips_its_own_output()
+    {
+        var value = new Poco("x", 1);
+        var bytes = _proxy.Serialize(value)!;
+
+        _proxy.TryDeserialize<Poco>((object)bytes, out var result).Should().BeTrue();
+        result.Should().Be(value);
+    }
+
+    /// <summary>A valid JSON null is a successful deserialization on every input shape; only an empty buffer is a failure.</summary>
+    [Fact]
+    public void TryDeserialize_object_treats_json_null_as_success_on_every_path()
+    {
+        var jsonNull = Encoding.UTF8.GetBytes("null");
+
+        _proxy.TryDeserialize<Poco>((object)jsonNull, out var fromBytes).Should().BeTrue();
+        fromBytes.Should().BeNull();
+
+        _proxy.TryDeserialize<Poco>((object)"null", out var fromText).Should().BeTrue();
+        fromText.Should().BeNull();
+
+        _proxy.TryDeserialize<Poco>(JsonSerializer.SerializeToElement<Poco?>(null), out var fromElement).Should().BeTrue();
+        fromElement.Should().BeNull();
+
+        _proxy.TryDeserialize<Poco>((object)Array.Empty<byte>(), out _).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Memory_of_byte_round_trips()
+    {
+        Memory<byte> memory = new byte[] { 4, 5, 6 };
+        var stored = _proxy.Serialize(memory)!;
+
+        stored.Should().Equal(4, 5, 6);
+        _proxy.Deserialize<Memory<byte>>(stored).ToArray().Should().Equal(4, 5, 6);
+    }
+}


### PR DESCRIPTION
## Summary

Adds a `Microsoft.Extensions.Caching.Distributed.IDistributedCache` implementation backed by the library's own pipeline (shared Redis connection, resilience, telemetry), built on two new core capabilities: configurable `CacheKey` casing and a byte-oriented serializer seam. Works as a `HybridCache` L2 out of the box (non-buffered paths; `IBufferDistributedCache` is a follow-up).

**First PR of 2.0.0** — it carries one deliberate breaking change, noted below.

## Changes

- **`IDistributedCache` adapter** — `builder.AddDistributedCache(providerName)` registers the adapter over a dedicated cache instance. The backing tier is a required argument (`Redis` recommended, `InMemoryRedis`, `InMemory`); full absolute + sliding expiration and `Refresh` are supported.
- **Storage layout** — each entry is a Redis **hash** with `data`, `absexp` and `sldexp` fields, the same shape `Microsoft.Extensions.Caching.StackExchangeRedis` uses, so `Refresh` reads only the expiration metadata instead of transferring the payload.
- **Keys are always case-sensitive**, independent of `CacheOptions.KeyCasing` — `IDistributedCache` keys are opaque and case-significant (session ids are base64url).
- **`CacheOptions.KeyCasing`** — app-wide `Insensitive` (trim + lowercase, the historical behavior and the default) or `Sensitive`. `CacheKey` gained a `(string?, CacheKeyCasing)` ctor, a `Casing` property and `WithName` so transformations preserve the mode. Note that changing this app-wide relocates every cache key.
- **`CacheKeyComparer`** — cached `Sensitive`/`Insensitive` comparers in the `StringComparer` shape.
- **`ISerializerProxy<byte[]>`** — new seam defaulting to `SystemJsonByteSerializerProxy`: byte payloads pass through raw, everything else is UTF-8 JSON, with the requested type argument deciding. The existing `ISerializerProxy<RedisValue>` registration and every existing wire format are untouched.
- **Options** — `InstanceName`, `PolicyName`, `DefaultEntryExpiration`, `AllowUnboundedEntries`. Writes with no caller expiration take a bounded default rather than living forever in shared storage; registration fails fast when no bounded default resolves and unbounded entries are not explicitly allowed.
- **Registration hardening** — `Replace` (not `TryAdd`) so a prior `AddDistributedMemoryCache()` cannot silently win; a second `AddDistributedCache` call throws instead of building the adapter from the first call's options over the second call's tier; disabled caching registers a null implementation so `AddSession()`/DataProtection still resolve; the tier's own `Enabled` switch is honored; `InMemoryRedis` requires the broadcast wiring `AddInMemoryRedis` installs; an unknown `PolicyName` fails fast.
- **Diagnostics** — log lines carry a short digest of the key, never the caller's key, which under ASP.NET Core session arrives straight from the client cookie. Failed writes and removes are logged rather than discarded.

### Keyspace separation (configurable)

Distributed entries are kept out of the application's own caches at two levels, both overridable on `UiPathDistributedCacheOptions` in the same nullable-with-a-default shape as the library's other strategy seams:

| Option | Default when null | Separates |
|---|---|---|
| `CacheKeyStrategy` | `PrefixCacheKeyStrategy` with `DefaultKeyPrefix` (`"d"`) | the `CacheKey` itself |
| `RedisKeyDifferentiator` | `DefaultRedisKeyDifferentiator` (`"dh"`) | the physical Redis keyspace |
| `RedisKeyStrategyFactory` | the application's own `RedisCacheOptions.RedisKeyStrategyFactory` | how the Redis key is built |

By default this composes `d:` + `InstanceName` + caller key, landing at `AppShortName:dh:d:<key>` on Redis. `DefaultCacheKeyStrategy` opts out of prefixing entirely, and nothing downstream assumes where the marker sits, so a suffix strategy works just as well.

**Why both levels.** The differentiator separates only the physical Redis keyspace, and only on Redis-backed tiers. The cache-key strategy travels in the `CacheKey` itself, so it also separates the memory tiers' **local lock keyspace** — `MultilayerCacheBase` keys local locks by provider name plus cache key name, the provider name is a shared constant, and `ILocalLock` is a DI singleton, so without key-level separation an application key and a distributed key of the same name would serialize against each other.

**Why the adapter applies the cache-key strategy** rather than the backing provider's own `ICacheOptions.CacheKeyStrategy`: that seam is only honored by `MultilayerHashCache`. `RedisHashCache` goes straight from `CacheKey` to `IRedisKeyStrategy` and ignores it, so routing through the provider would prefix `InMemory` and `InMemoryRedis` but not `Redis` — and since `MultilayerHashCache` passes the transformed key to its inner cache, the same logical entry would land under a different physical Redis key depending on the configured tier.

**Guards, since overriding these makes the separation the caller's to preserve.** Registration rejects a blank differentiator and one matching any `RedisTypePrefixes` value, and the adapter fails loudly if a custom strategy returns an empty key. A differentiator only separates anything if the factory honors it — and a factory that ignores the value it is handed is easy to write — so rather than assume, registration composes a probe key both ways and rejects a strategy that maps distributed entries onto the application's own keys.

### BREAKING

`CacheKey.Equals`/`GetHashCode` are now **ordinal** instead of `InvariantCultureIgnoreCase`. Insensitive keys are still lowercased at construction, so stored keys and comparisons between insensitive keys are unchanged; what changes is that equality is now consistent with `GetHashCode` (the old pairing could call two keys equal while hashing them to different buckets) and that `Sensitive` keys compare case-sensitively.

### Documented deviations from the MS implementation

`CacheKey` trims, so keys differing only in leading/trailing whitespace collide; no-expiration writes take a bounded default unless `AllowUnboundedEntries` is set; on the `InMemory` tier `LocalMaxExpiration` (1 hour by default) caps every entry, so that tier is for tests and single-node use.

## Test plan

- [x] Unit tests added/updated (~120 new across casing, comparers, serializers, adapter, keyspace seams, registration, and end-to-end sliding-session scenarios; the timing tests drive an injected `ISystemClock`, so they are deterministic rather than wall-clock races)
- [x] Integration tests pass locally (`dotnet test` — 1379 passed on net8.0 and net10.0)
- [x] CHANGELOG.md updated

## Linked issues

N/A

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources. <sub>(If checked, your employer may hold IP rights in this work, which can require a signed [CLA](https://github.com/UiPath/dotnet-caching/blob/main/CLA.md) — a maintainer will follow up. See [CONTRIBUTING.md](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla).)</sub>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BRcr7GtmVdMwAgKiKa88Dm
