### PR TITLE
chore(deps): bump net10 floor to 10.0.11 and guard per-TFM package floors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,8 @@ updates:
       # Microsoft.Extensions.* versions are framework-aligned via TFM-conditional
       # ItemGroups in Directory.Packages.props (net8 -> 8.x, net10 -> 10.x).
       # Block major bumps so Dependabot can't push 10.x onto the net8 target;
-      # cross-major moves are managed by hand.
+      # cross-major moves are managed by hand. Not sufficient on its own: a same-major bump
+      # can still land on the wrong floor, so PackageVersionFloorTests is the guard.
       - dependency-name: "Microsoft.Extensions.*"
         update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Changed
+
+- **`Microsoft.Extensions.*` dependency floor for `net10.0` raised to 10.0.11** (from 10.0.10).
+  The `net8.0` floor is unchanged at 8.0.x.
+
 ## [1.3.0] - 2026-08-19
 
 ### Added

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageVersion Include="MessagePack" Version="3.1.8" />
   </ItemGroup>
+  <!-- Per-TFM dependency floors: keep both groups in sync ID-for-ID, each on its own major. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
@@ -23,17 +24,17 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.30" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.11" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />

--- a/src/UiPath.Caching.Azure/UiPath.Caching.Azure.csproj
+++ b/src/UiPath.Caching.Azure/UiPath.Caching.Azure.csproj
@@ -8,7 +8,7 @@
     <PackageTags>UiPath;Caching;Azure;Entra;Redis</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" VersionOverride="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Azure.Identity" />
     <PackageReference Include="Microsoft.Azure.StackExchangeRedis" />

--- a/tests/UiPath.Caching.Tests/PackageVersionFloorTests.cs
+++ b/tests/UiPath.Caching.Tests/PackageVersionFloorTests.cs
@@ -1,0 +1,76 @@
+using System.Xml.Linq;
+
+namespace UiPath.Caching.Tests;
+
+/// <summary>
+/// Guards the per-TFM dependency floors in Directory.Packages.props. Dependabot does not evaluate the
+/// $(TargetFramework) conditions, so a bump can land on the wrong floor while restore still succeeds.
+/// </summary>
+public class PackageVersionFloorTests
+{
+    [Theory]
+    [InlineData("net8.0", 8)]
+    [InlineData("net10.0", 10)]
+    public void FloorGroupStaysOnItsOwnMajor(string tfm, int expectedMajor)
+    {
+        var offenders = FloorGroup(tfm)
+            .Select(PackageOf)
+            .Where(p => !p.Version.StartsWith($"{expectedMajor}.", StringComparison.Ordinal))
+            .Select(p => $"{p.Id} = {p.Version}")
+            .ToArray();
+
+        offenders.Should().BeEmpty(
+            $"the '{tfm}' ItemGroup is the dependency floor for {tfm} consumers and must stay on {expectedMajor}.x");
+    }
+
+    [Fact]
+    public void FloorGroupsDeclareTheSamePackages()
+    {
+        var net8 = FloorGroup("net8.0").Select(e => PackageOf(e).Id).Order().ToArray();
+        var net10 = FloorGroup("net10.0").Select(e => PackageOf(e).Id).Order().ToArray();
+
+        net8.Should().Equal(net10, "both floors must declare the same package IDs so neither TFM loses a pin");
+    }
+
+    [Fact]
+    public void FloorPackagesAreNotAlsoPinnedUnconditionally()
+    {
+        var floored = FloorGroup("net8.0").Concat(FloorGroup("net10.0"))
+            .Select(e => PackageOf(e).Id)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var unconditional = Root().Elements("ItemGroup")
+            .Where(g => g.Attribute("Condition") is null)
+            .SelectMany(g => g.Elements("PackageVersion"))
+            .Select(e => PackageOf(e).Id)
+            .Where(floored.Contains)
+            .ToArray();
+
+        unconditional.Should().BeEmpty(
+            "a package pinned both conditionally and unconditionally is ambiguous, which is what lets a bump land on the wrong line");
+    }
+
+    private static IEnumerable<XElement> FloorGroup(string tfm)
+    {
+        var group = Root().Elements("ItemGroup")
+            .SingleOrDefault(g => g.Attribute("Condition")?.Value.Contains($"'{tfm}'", StringComparison.Ordinal) == true);
+
+        group.Should().NotBeNull($"Directory.Packages.props should declare exactly one ItemGroup gated on '{tfm}'");
+        return group!.Elements("PackageVersion");
+    }
+
+    private static (string Id, string Version) PackageOf(XElement element) =>
+        (element.Attribute("Include")!.Value, element.Attribute("Version")!.Value);
+
+    private static XElement Root()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null && !File.Exists(Path.Combine(directory.FullName, "Directory.Packages.props")))
+        {
+            directory = directory.Parent;
+        }
+
+        directory.Should().NotBeNull("Directory.Packages.props should be findable by walking up from the test output directory");
+        return XDocument.Load(Path.Combine(directory!.FullName, "Directory.Packages.props")).Root!;
+    }
+}

--- a/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
+++ b/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <SonarQubeTestProject>true</SonarQubeTestProject>
-    <!-- AutoFixture.AutoNSubstitute 4.18.1 caps NSubstitute at <6, but 6.0.0 is used and passes; the pin is intentional. -->
+    <!-- AutoFixture.AutoNSubstitute 4.18.1 caps NSubstitute at <6, but 6.2.0 is used and passes; the pin is intentional. -->
     <NoWarn>$(NoWarn);NU1608</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
## Summary

Applies the `Microsoft.Extensions.*` bump that PRs #125/#126 were supposed to make (net10.0 floor 10.0.10 → 10.0.11), and adds a test that stops the same mistake from landing again.

`Directory.Packages.props` declares the same package IDs in two `$(TargetFramework)`-conditional `ItemGroup`s, one dependency floor per target. Dependabot does not evaluate those conditions: it reads the current version off one occurrence and writes the bump to the first matching line, which is in the *other* group. That is why #125/#126 were billed as `10.0.10 → 10.0.11` while actually raising the **net8.0** floor to 10.0.11 and leaving net10.0 untouched. Restore still succeeds in that state, so neither the build nor the existing `semver-major` ignore rule caught it — an ignore rule cannot express "not that line".

## Changes

- `Directory.Packages.props`: net10.0 floor 10.0.10 → 10.0.11 (11 entries); one-line comment naming the invariant.
- `UiPath.Caching.Azure`: `Microsoft.Extensions.Options` `VersionOverride` 10.0.10 → 10.0.11. Without this, restore fails `NU1605` (downgrade against the new floor). The override is load-bearing and kept deliberately — see the note below.
- `PackageVersionFloorTests` (new): each floor stays on its own major; both floors declare the same package IDs; no floored package is also pinned unconditionally.
- `.github/dependabot.yml`: note that the ignore rule is necessary but not sufficient, and that the test is the actual guard.
- `UiPath.Caching.Tests.csproj`: stale comment said NSubstitute 6.0.0, now 6.2.0.

## Test plan

- [x] Unit tests added/updated
- [x] Integration tests pass locally (`dotnet test`) — 1291 passed, 5 skipped, on both net8.0 and net10.0
- [x] CHANGELOG.md updated

The guard was verified against the real failure mode, not just asserted green: mutating the net8.0 `DependencyInjection` pin to 10.0.11 (exactly what #126 did) fails with

```
Expected offenders to be empty because the 'net8.0' ItemGroup is the dependency floor
for net8.0 consumers and must stay on 8.x, but found at least one item
{"Microsoft.Extensions.DependencyInjection = 10.0.11"}.
```

The test reads the props file as XML from the repo root, so it runs identically under both required checks.

## Note for reviewers — the net8.0 floor is already leaky

Removing the `Options` `VersionOverride` in `UiPath.Caching.Azure` does **not** restore: on net8.0, `Microsoft.Extensions.Hosting.Abstractions 10.0.3` arrives transitively and demands `Options >= 10.0.3`, conflicting with the 8.0.2 floor. The unconditional pins (`Logging.Abstractions 10.0.11`, `Http.Resilience 10.9.0`, `ServiceDiscovery 10.9.0`) apply to net8.0 too and pull 10.x in behind the floor's back, and that override is the existing spot fix.

Left as-is: deciding whether the net8.0 floor should hold at all is a separate call from applying a patch bump. Worth a follow-up issue if the floor is meant to be real.

## Linked issues

None — follows up on the closed #125 / #126.

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jrx2NqAusYzeSWZfDZdFzb

