### PR TITLE
chore(deps): move the OpenTelemetry family to 1.18.0 together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,13 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    groups:
+      # The OpenTelemetry packages are version-locked on each other; bumping them one PR at
+      # a time fails restore with NU1605. Keep the family in a single PR.
+      opentelemetry:
+        patterns:
+          - "OpenTelemetry"
+          - "OpenTelemetry.*"
     ignore:
       # Microsoft.Extensions.* versions are framework-aligned via TFM-conditional
       # ItemGroups in Directory.Packages.props (net8 -> 8.x, net10 -> 10.x).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - **`Microsoft.Extensions.*` dependency floor for `net10.0` raised to 10.0.11** (from 10.0.10).
   The `net8.0` floor is unchanged at 8.0.x.
+- **OpenTelemetry packages moved to 1.18.0** (`OpenTelemetry.Instrumentation.StackExchangeRedis` to 1.18.0-beta.1).
 
 ## [1.3.0] - 2026-08-19
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -50,14 +50,14 @@
     <PackageVersion Include="CloudNative.CloudEvents.SystemTextJson" Version="$(CloudEvents)" />
     <PackageVersion Include="Polly.Core" Version="8.7.0" />
     <PackageVersion Include="Polly.Extensions" Version="8.7.0" />
-    <PackageVersion Include="OpenTelemetry" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.17.0-beta.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
+    <PackageVersion Include="OpenTelemetry" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.18.0-beta.1" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.18.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.18.0" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
     <!-- Public API surface tracking (src libraries only; wired in src/Directory.Build.props) -->


### PR DESCRIPTION
## Summary

Moves all eight OpenTelemetry packages to 1.18.0 in one step, replacing #137/#138/#139, and groups the family in `dependabot.yml` so future updates arrive as a single PR.

The OpenTelemetry packages are version-locked on each other, so bumping them one at a time does not work. #138 and #139 **failed CI** with `NU1605`:

```
Detected package downgrade: OpenTelemetry from 1.18.0 to 1.17.0
  UiPath.Caching.Sample -> UiPath.Caching.Sample.ServiceDefaults
    -> OpenTelemetry.Exporter.OpenTelemetryProtocol 1.18.0 -> OpenTelemetry (>= 1.18.0)
  UiPath.Caching.Sample -> OpenTelemetry (>= 1.17.0)
```

#137 was the only green one, and only because Dependabot added a direct `<PackageReference Include="OpenTelemetry" />` to `UiPath.Caching.Sample.ServiceDefaults` to work around its own partial bump. That project file change is not needed once the family moves in step, and is not included here.

## Changes

- `Directory.Packages.props`: all eight `OpenTelemetry*` pins 1.17.0 → 1.18.0. `OpenTelemetry.Instrumentation.StackExchangeRedis` goes to 1.18.0-beta.1, staying on its prerelease line — that package has no stable 1.18.0.
- `.github/dependabot.yml`: new `opentelemetry` group covering `OpenTelemetry` and `OpenTelemetry.*`, so the family is bumped in one PR instead of eight racing ones.

No project file changes.

## Test plan

- [x] Unit tests added/updated — n/a, dependency-only change
- [x] Integration tests pass locally (`dotnet test`) — 1291 passed, 5 skipped, on both net8.0 and net10.0; restore and build clean with no `NU1605`
- [x] CHANGELOG.md updated

## Linked issues

Replaces #137, #138, #139 — please close those in favour of this.

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jrx2NqAusYzeSWZfDZdFzb
