### PR TITLE
fix(cache): rebuild the Redis connection when a discovered cluster node is retired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   fire on exceptions only, and re-issuing `NX` is harmless, since an attempt whose reply was lost is
   refused by the key it just wrote and reports the same `false` the exception would have, while an
   attempt that never reached Redis is recovered as the `true` it should have been.
+- **Stale cluster endpoint detection.** `RedisConnector` now rebuilds the multiplexer when a cluster
+  node it discovered has left the cluster but is still being retried. StackExchange.Redis never forgets
+  a server it has seen, so when a node is replaced — an Azure Managed Redis patch swaps the node VMs
+  and retires their endpoints — the old address is retried and logged as an error every few seconds
+  for the life of the process; only a fresh multiplexer re-reads the topology. Every
+  `StaleEndpointScanInterval` (default 30 s) the connector notes which topology-discovered servers are
+  disconnected; one that stays down for `StaleEndpointThreshold` (default 5 min) is checked against
+  `CLUSTER NODES` on a connected server, and if it is no longer a member the connector emits
+  `Redis.StaleEndpointDetected` and calls `ForceReconnect()`. Configured endpoints are never judged
+  stale, a node that is down but still in the cluster is left to StackExchange.Redis, and a
+  non-cluster server is ignored. Opt out with `EnableStaleEndpointDetection = false`. `RedisConnector`
+  gains a constructor overload that takes a `TimeProvider`; the existing one keeps using `TimeProvider.System`.
+  `RedisHealthCheck` reports the disconnected endpoints under
+  `ConnectionMultiplexer.DisconnectedEndPoints`.
 
 ### Changed
 

--- a/docs/how-to/resilience.md
+++ b/docs/how-to/resilience.md
@@ -412,6 +412,37 @@ cache support.
 }
 ```
 
+## Redis connection self-healing
+
+`RedisConnector` owns one `ConnectionMultiplexer` and lets StackExchange.Redis reconnect on its
+own. Three watchdogs cover the cases where that is not enough; each ends in
+`IRedisConnector.ForceReconnect()`, which builds a fresh multiplexer, swaps it in, and closes the
+old one (`Redis.ForcedReconnect` event, `OnReconnected` raised).
+
+| Watchdog | Trigger | Settings |
+|---|---|---|
+| Hang detection | More than 100 commands awaiting a reply on the primary with no read or write for `LastWrite/ReadIntervalThresholdMilliseconds` | `EnableHangDetection`, `HangDetectionDueTime`, `HangDetectionPeriod` |
+| Planned maintenance | `NodeMaintenanceStarting` on the `AzureRedisEvents` channel; probes with a write every second for 10 minutes and reconnects on failure | `PlannedMaintenanceEnabled` |
+| Stale endpoint detection | A topology-discovered node has been disconnected for `StaleEndpointThreshold` and is no longer listed by `CLUSTER NODES` | `EnableStaleEndpointDetection`, `StaleEndpointThreshold`, `StaleEndpointScanInterval` |
+
+**Stale endpoints** are the clustered-cache failure mode. StackExchange.Redis discovers the
+node addresses behind the endpoint you configure and then never forgets one. When a provider
+replaces a node — an Azure Managed Redis patch creates new VMs, migrates the shards, and deletes
+the old ones — the retired address stays in the multiplexer and is retried on the reconnect
+policy forever, logging `It was not possible to connect to the redis server(s) <ip:port>` at
+`Error` every few seconds. Commands still flow to the surviving nodes, so nothing else trips.
+The scan only judges endpoints the multiplexer discovered (never the ones in your connection
+string), only after they have been down for the threshold, and only when a connected server
+confirms the node is gone. A node that is down but still a cluster member is left alone. On a
+non-cluster server the membership query fails and the scan does nothing.
+
+**Which Azure offering sends maintenance events.** The `AzureRedisEvents` channel exists on
+Azure Cache for Redis Basic, Standard and Premium only. Azure Managed Redis (`*.redis.azure.net`)
+does not publish it, so on that service `PlannedMaintenanceEnabled` never fires and the
+planned-maintenance state never reports in-progress; the stale-endpoint scan and hang detection
+are what recover a connection there. Microsoft's own guidance for Azure Managed Redis is the same
+ForceReconnect pattern: recreate the multiplexer when errors persist past a threshold.
+
 ### Don't roll your own
 
 If you're reaching for `IRedisConnector.Database` directly — manual `StringSet` + JSON,
@@ -432,6 +463,7 @@ Use this table to pick the right knob for a given problem.
 | Redis goes slow or unavailable and callers queue up waiting | Polly circuit-breaker | `AddResilienceStrategies()` + `ExceptionsAllowedBeforeBreaking` |
 | Some caches need different TTLs or rehydrate settings than others | Named policies | `Policies["MyApp.Models.Order"]` |
 | Need per-call TTL overrides without a separate cache instance | Per-call expiration | `expiration:` argument on `GetOrAddAsync` / `SetAsync` |
+| `It was not possible to connect to the redis server(s) <ip:port>` logged every few seconds after a cluster patch | Stale endpoint detection | `EnableStaleEndpointDetection: true` (default), `StaleEndpointThreshold` |
 
 ## Common pitfalls
 

--- a/docs/recipes/redis-health-check.md
+++ b/docs/recipes/redis-health-check.md
@@ -34,6 +34,10 @@ app.MapHealthChecks("/healthz");
 
 A 3-second timeout is the conventional value — longer than a typical ping (sub-100 ms) but short enough that a hung Redis doesn't keep the probe waiting indefinitely.
 
+The healthy result carries the multiplexer's `IsConnected`, `IsConnecting`, `OperationCount`, `Status` and `DisconnectedEndPoints` (a `;`-joined `host:port` list) in its data, so a probe that is green can still show a node the multiplexer cannot reach. A discovered node that stays in that list after a cluster patch is what [stale endpoint detection](../how-to/resilience.md#redis-connection-self-healing) removes by rebuilding the connection; the health check does not need to fail for that to happen.
+
+`IRedisPlannedMaintenance.InProgress` only ever becomes `true` on Azure Cache for Redis Basic/Standard/Premium, the tiers that publish the `AzureRedisEvents` channel. On Azure Managed Redis the check behaves as if no maintenance tracker were registered.
+
 ## When not to use
 
 - Services that use `AddMemory()` only (no Redis) — `IRedisConnector` isn't registered. Use the standard `Microsoft.Extensions.Diagnostics.HealthChecks` ping or a no-op check instead.

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -63,6 +63,9 @@ Every binding-visible property on every shipped options class, with shipped defa
 | `DefaultVersion` | `string?` | `"6.0"` | App-wide | Redis server version hint passed to StackExchange.Redis for command compatibility. |
 | `HangDetectionDueTime` | `TimeSpan?` | `null` | App-wide | Delay before the first hang-detection check; `null` = 30 s library default. |
 | `HangDetectionPeriod` | `TimeSpan?` | `null` | App-wide | Period between hang-detection checks; `null` = library default. |
+| `EnableStaleEndpointDetection` | `bool` | `true` | App-wide | Rebuild the connection when a cluster node the multiplexer discovered has left the cluster but is still being retried (see [Redis connection self-healing](../how-to/resilience.md#redis-connection-self-healing)). |
+| `StaleEndpointThreshold` | `TimeSpan` | `00:05:00` | App-wide | How long a discovered endpoint must stay disconnected before its cluster membership is checked; non-positive falls back to the default. |
+| `StaleEndpointScanInterval` | `TimeSpan` | `00:00:30` | App-wide | Period between stale-endpoint scans; non-positive falls back to the default. |
 | `FailFastBacklogPolicy` | `bool?` | `null` | App-wide | `null` = library default; `true` = fail immediately when the command backlog is full. |
 | `ProfilerEnabled` | `bool` | `false` | App-wide | Enable StackExchange.Redis command profiler. |
 | `ProfilerHasDefaultSession` | `bool` | `true` | App-wide | Start a default profiling session automatically at startup. |

--- a/samples/UiPath.Caching.Sample/appsettings.all.json
+++ b/samples/UiPath.Caching.Sample/appsettings.all.json
@@ -70,6 +70,12 @@
         "HangDetectionDueTime": null,
         // HangDetectionPeriod: null = use library default; period between hang-detection checks
         "HangDetectionPeriod": null,
+        // EnableStaleEndpointDetection: rebuild the connection when a discovered cluster node has left the cluster but is still being retried
+        "EnableStaleEndpointDetection": true,
+        // StaleEndpointThreshold: how long a discovered endpoint must stay disconnected before its cluster membership is checked
+        "StaleEndpointThreshold": "00:05:00",
+        // StaleEndpointScanInterval: period between stale-endpoint scans
+        "StaleEndpointScanInterval": "00:00:30",
         // FailFastBacklogPolicy: null = library default; true = fail immediately when backlog is full
         "FailFastBacklogPolicy": null,
         // ProfilerEnabled: enable StackExchange.Redis command profiler

--- a/src/UiPath.Caching/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Unshipped.txt
@@ -94,3 +94,10 @@ UiPath.Caching.Redis.RedisCacheBase.RedisCacheBase(UiPath.Caching.Redis.IRedisCo
 UiPath.Caching.Redis.RedisCacheProvider.RedisCacheProvider(Microsoft.Extensions.Options.IOptions<UiPath.Caching.Redis.RedisCacheOptions!>! redisCacheOptions, Microsoft.Extensions.Options.IOptions<UiPath.Caching.CacheOptions!>! cacheOptions, UiPath.Caching.Redis.IRedisConnector! redis, UiPath.Caching.ISerializerProxy<byte[]!>! serializerProxy, UiPath.Caching.Policies.IResiliencePipelineProvider! resiliencePipelineProvider, UiPath.Caching.Telemetry.ICachingTelemetryProvider! cachingTelemetryProvider, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, UiPath.Caching.ICachePolicyFactory! policyFactory, System.TimeProvider! clock) -> void
 readonly UiPath.Caching.MultilayerCacheBase._clock -> System.TimeProvider!
 static UiPath.Caching.Config.ServiceCollectionExtensions.TryAddTimeProvider(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+UiPath.Caching.Redis.RedisConnector.RedisConnector(UiPath.Caching.Telemetry.ICachingTelemetryProvider! telemetryProvider, UiPath.Caching.Redis.IRedisConfigurationOptionsProvider! redisConfigurationOptionsProvider, UiPath.Caching.Redis.IConnectionMultiplexerFactory! connectionMultiplexerFactory, Microsoft.Extensions.Options.IOptions<UiPath.Caching.Redis.RedisConnectionOptions!>! redisOptions, System.Collections.Generic.IEnumerable<UiPath.Caching.Redis.IRedisConnectionConfigurator!>? configurators, System.TimeProvider? clock) -> void
+UiPath.Caching.Redis.RedisConnectionOptions.EnableStaleEndpointDetection.get -> bool
+UiPath.Caching.Redis.RedisConnectionOptions.EnableStaleEndpointDetection.set -> void
+UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointThreshold.get -> System.TimeSpan
+UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointThreshold.set -> void
+UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointScanInterval.get -> System.TimeSpan
+UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointScanInterval.set -> void

--- a/src/UiPath.Caching/Redis/RedisConnectionOptions.cs
+++ b/src/UiPath.Caching/Redis/RedisConnectionOptions.cs
@@ -42,6 +42,13 @@ public class RedisConnectionOptions
 
     public TimeSpan? HangDetectionPeriod { get; set; }
 
+    /// <summary>Rebuild the connection when a discovered cluster node has left the cluster; StackExchange.Redis retries a retired node forever.</summary>
+    public bool EnableStaleEndpointDetection { get; set; } = true;
+
+    public TimeSpan StaleEndpointThreshold { get; set; } = TimeSpan.FromMinutes(5);
+
+    public TimeSpan StaleEndpointScanInterval { get; set; } = TimeSpan.FromSeconds(30);
+
     public bool? FailFastBacklogPolicy { get; set; }
 
     public bool ProfilerEnabled { get; set; }

--- a/src/UiPath.Caching/Redis/RedisConnector.cs
+++ b/src/UiPath.Caching/Redis/RedisConnector.cs
@@ -13,12 +13,17 @@ public sealed class RedisConnector : IRedisConnector
     private readonly IConnectionMultiplexerFactory _connectionMultiplexerFactory;
     private readonly IEnumerable<IRedisConnectionConfigurator>? _configurators;
     private readonly Timer? _hangDetectionTimer;
+    private readonly ITimer? _staleEndpointTimer;
+    private readonly TimeSpan _staleEndpointThreshold;
+    private readonly TimeProvider _clock;
+    private readonly Dictionary<EndPoint, long> _disconnectedSince = [];
     private readonly Lazy<Version> _version;
     private readonly object _swapLock = new();
 
     private volatile Lazy<Task<IConnectionMultiplexer>> _lazyCacheConnectionMultiplexer;
     private volatile bool _disposed;
     private int _reconnecting;
+    private int _staleScanRunning;
     private ReadWriteStatus? _lastMasterMetrics;
 
     public RedisConnector(ICachingTelemetryProvider telemetryProvider,
@@ -26,6 +31,16 @@ public sealed class RedisConnector : IRedisConnector
         IConnectionMultiplexerFactory connectionMultiplexerFactory,
         IOptions<RedisConnectionOptions> redisOptions,
         IEnumerable<IRedisConnectionConfigurator>? configurators = null)
+        : this(telemetryProvider, redisConfigurationOptionsProvider, connectionMultiplexerFactory, redisOptions, configurators, null)
+    {
+    }
+
+    public RedisConnector(ICachingTelemetryProvider telemetryProvider,
+        IRedisConfigurationOptionsProvider redisConfigurationOptionsProvider,
+        IConnectionMultiplexerFactory connectionMultiplexerFactory,
+        IOptions<RedisConnectionOptions> redisOptions,
+        IEnumerable<IRedisConnectionConfigurator>? configurators,
+        TimeProvider? clock)
     {
         _redisOptions = redisOptions.Value;
 
@@ -35,11 +50,18 @@ public sealed class RedisConnector : IRedisConnector
         _redisConfigurationOptionsProvider = redisConfigurationOptionsProvider;
         _connectionMultiplexerFactory = connectionMultiplexerFactory;
         _configurators = configurators;
+        _clock = clock ?? TimeProvider.System;
         if (_redisOptions.EnableHangDetection)
         {
             var hangDetectionDueTime = _redisOptions.HangDetectionDueTime ?? TimeSpan.FromSeconds(30);
             var hangDetectionPeriod = _redisOptions.HangDetectionPeriod ?? TimeSpan.FromSeconds(5);
             _hangDetectionTimer = new Timer(_ => OnHangScan(), null, hangDetectionDueTime, hangDetectionPeriod);
+        }
+        _staleEndpointThreshold = _redisOptions.StaleEndpointThreshold > TimeSpan.Zero ? _redisOptions.StaleEndpointThreshold : TimeSpan.FromMinutes(5);
+        if (_redisOptions.EnableStaleEndpointDetection)
+        {
+            var scanInterval = _redisOptions.StaleEndpointScanInterval > TimeSpan.Zero ? _redisOptions.StaleEndpointScanInterval : TimeSpan.FromSeconds(30);
+            _staleEndpointTimer = _clock.CreateTimer(state => _ = ScanStaleEndpointsAsync(), null, scanInterval, scanInterval);
         }
         _version = new Lazy<Version>(GetVersion);
     }
@@ -114,14 +136,15 @@ public sealed class RedisConnector : IRedisConnector
             : [];
     }
 
-    public void ForceReconnect()
+    public void ForceReconnect() => ForceReconnect(_lazyCacheConnectionMultiplexer);
+
+    private void ForceReconnect(Lazy<Task<IConnectionMultiplexer>> current)
     {
-        if (_disposed)
+        if (_disposed || !ReferenceEquals(_lazyCacheConnectionMultiplexer, current))
         {
             return;
         }
 
-        var current = _lazyCacheConnectionMultiplexer;
         if (!current.IsValueCreated || !current.Value.IsCompleted)
         {
             return;
@@ -307,8 +330,181 @@ public sealed class RedisConnector : IRedisConnector
             }
 
             _hangDetectionTimer?.Dispose();
+            _staleEndpointTimer?.Dispose();
         }
     }
+
+    /// <summary>Only topology-discovered endpoints can go stale; configured ones are left to StackExchange.Redis.</summary>
+    internal async Task ScanStaleEndpointsAsync()
+    {
+        if (_disposed || Volatile.Read(ref _reconnecting) > 0)
+        {
+            return;
+        }
+
+        var lazy = _lazyCacheConnectionMultiplexer;
+        if (!lazy.IsValueCreated || !lazy.Value.IsCompletedSuccessfully)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref _staleScanRunning, 1, 0) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var stale = await FindStaleEndpointsAsync(lazy.Value.Result).ConfigureAwait(false);
+            if (stale.Count == 0 || !ReferenceEquals(_lazyCacheConnectionMultiplexer, lazy))
+            {
+                return;
+            }
+
+            _telemetryProvider.TrackEvent(
+                "Redis.StaleEndpointDetected",
+                [
+                    new("EndPoints", string.Join(";", stale.Select(FormatEndPoint))),
+                    new("Threshold", _staleEndpointThreshold.ToString()),
+                ]);
+            ForceReconnect(lazy); // the timestamps stay until a scan of the new multiplexer prunes them, so a failed rebuild is retried next scan
+        }
+        catch (Exception ex)
+        {
+            _telemetryProvider.TrackException(ex);
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _staleScanRunning, 0);
+        }
+    }
+
+    private async Task<List<EndPoint>> FindStaleEndpointsAsync(IConnectionMultiplexer multiplexer)
+    {
+        var now = _clock.GetTimestamp();
+        var configured = multiplexer.GetEndPoints(configuredOnly: true);
+        IServer? connected = null;
+        var disconnected = new List<IServer>();
+        foreach (var server in multiplexer.GetServers())
+        {
+            if (server.IsConnected)
+            {
+                connected ??= server;
+            }
+            else if (Array.IndexOf(configured, server.EndPoint) < 0)
+            {
+                disconnected.Add(server);
+            }
+        }
+
+        foreach (var endpoint in _disconnectedSince.Keys.Where(e => !disconnected.Exists(s => s.EndPoint.Equals(e))).ToArray())
+        {
+            _disconnectedSince.Remove(endpoint);
+        }
+
+        var overdue = new List<EndPoint>();
+        foreach (var endpoint in disconnected.Select(s => s.EndPoint))
+        {
+            if (!_disconnectedSince.TryGetValue(endpoint, out var since))
+            {
+                _disconnectedSince[endpoint] = now;
+            }
+            else if (_clock.GetElapsedTime(since, now) >= _staleEndpointThreshold)
+            {
+                overdue.Add(endpoint);
+            }
+        }
+
+        if (overdue.Count == 0 || connected is null)
+        {
+            return [];
+        }
+
+        var members = await GetClusterMemberAddressesAsync(connected).ConfigureAwait(false);
+        return members is null ? [] : overdue.Where(ep => !members.Contains(FormatEndPoint(ep))).ToList();
+    }
+
+    private static async Task<HashSet<string>?> GetClusterMemberAddressesAsync(IServer server)
+    {
+        try
+        {
+            var members = ParseClusterNodeAddresses(await server.ClusterNodesRawAsync().ConfigureAwait(false));
+            return members.Count == 0 ? null : members; // a real reply lists at least the answering node
+        }
+        catch (RedisServerException ex) when (IsNotACluster(ex))
+        {
+            return null;
+        }
+    }
+
+    private static bool IsNotACluster(RedisServerException ex) =>
+        ex.Message.Contains("cluster support disabled", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.StartsWith("ERR unknown command", StringComparison.OrdinalIgnoreCase)
+        || ex.Message.StartsWith("ERR unknown subcommand", StringComparison.OrdinalIgnoreCase);
+
+    internal static HashSet<string> ParseClusterNodeAddresses(string? clusterNodes)
+    {
+        var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (string.IsNullOrWhiteSpace(clusterNodes))
+        {
+            return addresses;
+        }
+
+        foreach (var line in clusterNodes.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            AddNodeAddresses(line, addresses);
+        }
+
+        return addresses;
+    }
+
+    private static void AddNodeAddresses(string line, HashSet<string> addresses)
+    {
+        var fields = line.Split(' ');
+        if (fields.Length < 3 || fields[2].Contains("noaddr", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        // <ip:port@cport[,hostname[,aux=value...]]>
+        var address = fields[1].AsSpan();
+        var at = address.IndexOf('@');
+        var hostPort = at < 0 ? address : address[..at];
+        var portSeparator = hostPort.LastIndexOf(':');
+        if (portSeparator < 0)
+        {
+            return;
+        }
+
+        var port = hostPort[(portSeparator + 1)..];
+        addresses.Add(IPAddress.TryParse(hostPort[..portSeparator], out var ip) ? $"{ip}:{port}" : hostPort.ToString()); // canonical spelling, as FormatEndPoint produces
+        var hostname = HostnameSegment(at < 0 ? default : address[(at + 1)..]);
+        if (!hostname.IsEmpty)
+        {
+            addresses.Add($"{hostname}:{port}");
+        }
+    }
+
+    /// <summary>The hostname is the first comma-separated segment after the cluster port; anything after it is auxiliary.</summary>
+    private static ReadOnlySpan<char> HostnameSegment(ReadOnlySpan<char> afterAt)
+    {
+        var comma = afterAt.IndexOf(',');
+        if (comma < 0)
+        {
+            return default;
+        }
+
+        var hostname = afterAt[(comma + 1)..];
+        var next = hostname.IndexOf(',');
+        return next < 0 ? hostname : hostname[..next];
+    }
+
+    internal static string FormatEndPoint(EndPoint endPoint) => endPoint switch
+    {
+        IPEndPoint ip => $"{ip.Address}:{ip.Port}",
+        DnsEndPoint dns => $"{dns.Host}:{dns.Port}",
+        _ => endPoint.ToString() ?? string.Empty,
+    };
 
     private void TryDisposeMultiplexer(IConnectionMultiplexer multiplexer)
     {

--- a/src/UiPath.Caching/Redis/RedisHealthCheck.cs
+++ b/src/UiPath.Caching/Redis/RedisHealthCheck.cs
@@ -31,6 +31,7 @@ public class RedisHealthCheck : IHealthCheck
                     { "ConnectionMultiplexer.IsConnecting",  _redisConnector.Database.Multiplexer ?.IsConnecting ?? false },
                     { "ConnectionMultiplexer.OperationCount",  _redisConnector.Database.Multiplexer?.OperationCount ?? -1 },
                     { "ConnectionMultiplexer.Status",  _redisConnector.Database.Multiplexer?.GetStatus() ?? "N/A" },
+                    { "ConnectionMultiplexer.DisconnectedEndPoints", DisconnectedEndPoints(_redisConnector.Database.Multiplexer) },
                 });
         }
         catch (Exception ex)
@@ -38,4 +39,9 @@ public class RedisHealthCheck : IHealthCheck
             return new HealthCheckResult(context.Registration.FailureStatus, exception: ex);
         }
     }
+
+    private static string DisconnectedEndPoints(IConnectionMultiplexer? multiplexer) =>
+        multiplexer is null
+            ? "N/A"
+            : string.Join(";", multiplexer.GetServers().Where(s => !s.IsConnected).Select(s => RedisConnector.FormatEndPoint(s.EndPoint)));
 }

--- a/tests/UiPath.Caching.Tests/Redis/RedisConnectorStaleEndpointTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConnectorStaleEndpointTests.cs
@@ -1,0 +1,366 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
+using UiPath.Caching.Telemetry;
+
+namespace UiPath.Caching.Tests.Redis;
+
+public class RedisConnectorStaleEndpointTests
+{
+    private const string ClusterNodesWithoutRetiredNodes =
+        "07c3 4.195.18.22:8500@18500 myself,master - 0 0 1 connected 0-8191\n" +
+        "a1b2 4.195.18.22:8501@18501 master - 0 1 2 connected 8192-16383\n";
+
+    private static readonly DnsEndPoint Seed = new("redis.example.net", 10000);
+    private static readonly IPEndPoint Live = new(IPAddress.Parse("4.195.18.22"), 8500);
+    private static readonly IPEndPoint Retired = new(IPAddress.Parse("4.195.18.22"), 8502);
+
+    private sealed class AdvancingTimeProvider : TimeProvider
+    {
+        private readonly List<FakeTimer> _timers = [];
+        private DateTimeOffset _now = new(2026, 9, 3, 23, 36, 0, TimeSpan.Zero);
+
+        public override DateTimeOffset GetUtcNow() => _now;
+        public override long GetTimestamp() => _now.UtcTicks;
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period)
+        {
+            var timer = new FakeTimer(callback, state, _now + dueTime, period);
+            _timers.Add(timer);
+            return timer;
+        }
+
+        public void Advance(TimeSpan by)
+        {
+            var target = _now + by;
+            while (_timers.Where(t => t.Due <= target).MinBy(t => t.Due) is { } next)
+            {
+                _now = next.Due!.Value;
+                next.Fire();
+            }
+            _now = target;
+        }
+
+        private sealed class FakeTimer(TimerCallback callback, object? state, DateTimeOffset due, TimeSpan period) : ITimer
+        {
+            public DateTimeOffset? Due { get; private set; } = due;
+
+            public void Fire()
+            {
+                Due = period > TimeSpan.Zero ? Due + period : null;
+                callback(state);
+            }
+
+            public bool Change(TimeSpan dueTime, TimeSpan period) => false;
+            public void Dispose() => Due = null;
+            public ValueTask DisposeAsync()
+            {
+                Due = null;
+                return ValueTask.CompletedTask;
+            }
+        }
+    }
+
+    private sealed class SequenceFactory(params IConnectionMultiplexer[] multiplexers) : IConnectionMultiplexerFactory
+    {
+        private readonly Queue<IConnectionMultiplexer> _multiplexers = new(multiplexers);
+        public int CreateCount { get; private set; }
+        public ValueTask<IConnectionMultiplexer> CreateAsync(ConfigurationOptions configuration, CancellationToken cancellationToken = default)
+        {
+            CreateCount++;
+            return new ValueTask<IConnectionMultiplexer>(_multiplexers.Dequeue());
+        }
+    }
+
+    private sealed class RecordingTelemetry : ICachingTelemetryProvider
+    {
+        public List<string> Events { get; } = [];
+        public List<Exception> Exceptions { get; } = [];
+        public void TrackException(Exception ex, ReadOnlySpan<KeyValuePair<string, string>> properties = default, ReadOnlySpan<KeyValuePair<string, double>> metrics = default) => Exceptions.Add(ex);
+        public void TrackEvent(string eventName, ReadOnlySpan<KeyValuePair<string, string>> properties = default, ReadOnlySpan<KeyValuePair<string, double>> metrics = default) => Events.Add(eventName);
+    }
+
+#pragma warning disable CS0618 // the replacement constructor takes RedisErrorKind, which is still experimental (SER007)
+    private static RedisServerException ServerError(string message) => new(message);
+#pragma warning restore CS0618
+
+    private sealed class Harness
+    {
+        public AdvancingTimeProvider Clock { get; } = new();
+        public RecordingTelemetry Telemetry { get; } = new();
+        public IConnectionMultiplexer Multiplexer { get; } = Substitute.For<IConnectionMultiplexer>();
+        public IConnectionMultiplexer Replacement { get; } = Substitute.For<IConnectionMultiplexer>();
+        public IServer LiveServer { get; } = Server(Live, connected: true);
+        public IServer RetiredServer { get; } = Server(Retired, connected: false);
+        public SequenceFactory Factory { get; }
+        public RedisConnector Connector { get; }
+        public TaskCompletionSource OldDisposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Harness(string clusterNodes = ClusterNodesWithoutRetiredNodes, bool retiredIsConfigured = false, bool replacementAvailable = true, bool timerDriven = false)
+        {
+            Multiplexer.GetEndPoints(true).Returns(retiredIsConfigured ? [Seed, Retired] : [Seed]);
+            Multiplexer.GetServers().Returns([LiveServer, RetiredServer]);
+            Multiplexer.CloseAsync(Arg.Any<bool>()).Returns(Task.CompletedTask);
+            Multiplexer.When(m => m.Dispose()).Do(_ => OldDisposed.TrySetResult());
+            LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>()).Returns(Task.FromResult<string?>(clusterNodes));
+
+            Factory = replacementAvailable ? new SequenceFactory(Multiplexer, Replacement) : new SequenceFactory(Multiplexer);
+            var options = Options.Create(new RedisConnectionOptions
+            {
+                ConnectionString = "redis.example.net:10000",
+                EnableHangDetection = false,
+                EnableStaleEndpointDetection = timerDriven, // otherwise the test calls the scan itself
+                StaleEndpointThreshold = TimeSpan.FromMinutes(5),
+                StaleEndpointScanInterval = TimeSpan.FromSeconds(30),
+            });
+            var optionsProvider = new RedisConfigurationOptionsProvider(NullLoggerFactory.Instance, options);
+            Connector = new RedisConnector(Telemetry, optionsProvider, Factory, options, configurators: null, clock: Clock);
+        }
+
+        public async Task ScanTwiceAcrossThresholdAsync()
+        {
+            await Connector.ConnectAsync(TestContext.Current.CancellationToken);
+            await Connector.ScanStaleEndpointsAsync();
+            Clock.Advance(TimeSpan.FromMinutes(5));
+            await Connector.ScanStaleEndpointsAsync();
+        }
+
+        private static IServer Server(EndPoint endPoint, bool connected)
+        {
+            var server = Substitute.For<IServer>();
+            server.EndPoint.Returns(endPoint);
+            server.IsConnected.Returns(connected);
+            return server;
+        }
+    }
+
+    [Fact]
+    public async Task Scan_ForcesReconnect_WhenDiscoveredEndpointLeftClusterAndStayedDownPastThreshold()
+    {
+        var h = new Harness();
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().ContainInOrder("Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Timer_DrivesTheScan_ThroughTheInjectedClock()
+    {
+        var h = new Harness(timerDriven: true);
+        await h.Connector.ConnectAsync(TestContext.Current.CancellationToken);
+
+        h.Clock.Advance(TimeSpan.FromMinutes(5)); // first tick at 30 s records the outage; 4.5 min later it is not yet overdue
+        h.Factory.CreateCount.Should().Be(1);
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().ContainInOrder("Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_DoesNothing_BeforeThreshold()
+    {
+        var h = new Harness();
+        await h.Connector.ConnectAsync(TestContext.Current.CancellationToken);
+
+        await h.Connector.ScanStaleEndpointsAsync();
+        h.Clock.Advance(TimeSpan.FromMinutes(4));
+        await h.Connector.ScanStaleEndpointsAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Events.Should().BeEmpty();
+        await h.LiveServer.DidNotReceive().ClusterNodesRawAsync(Arg.Any<CommandFlags>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_DoesNothing_WhenDownEndpointIsStillAClusterMember()
+    {
+        var h = new Harness(ClusterNodesWithoutRetiredNodes + "c3d4 4.195.18.22:8502@18502 slave 07c3 0 1 1 disconnected\n");
+
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_IgnoresConfiguredEndpoints()
+    {
+        var h = new Harness(retiredIsConfigured: true);
+
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        await h.LiveServer.DidNotReceive().ClusterNodesRawAsync(Arg.Any<CommandFlags>());
+        h.Connector.Dispose();
+    }
+
+    [Theory]
+    [InlineData("ERR This instance has cluster support disabled")]
+    [InlineData("ERR unknown command 'CLUSTER'")]
+    public async Task Scan_DoesNothing_WhenServerIsNotACluster(string error)
+    {
+        var h = new Harness();
+        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>())
+            .Returns<string?>(_ => throw ServerError(error));
+
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_TracksOtherServerErrors_WithoutReconnecting()
+    {
+        var h = new Harness();
+        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>())
+            .Returns<string?>(_ => throw ServerError("NOPERM this user has no permissions to run the 'cluster|nodes' command"));
+
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Telemetry.Exceptions.Should().ContainSingle().Which.Should().BeOfType<RedisServerException>();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_RestartsTheClock_WhenEndpointReconnectsInBetween()
+    {
+        var h = new Harness();
+        await h.Connector.ConnectAsync(TestContext.Current.CancellationToken);
+
+        await h.Connector.ScanStaleEndpointsAsync();
+        h.RetiredServer.IsConnected.Returns(true);
+        h.Clock.Advance(TimeSpan.FromMinutes(3));
+        await h.Connector.ScanStaleEndpointsAsync();
+        h.RetiredServer.IsConnected.Returns(false);
+        h.Clock.Advance(TimeSpan.FromMinutes(3));
+        await h.Connector.ScanStaleEndpointsAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("garbage")]
+    public async Task Scan_DoesNothing_WhenClusterNodesReplyIsUnusable(string? reply)
+    {
+        var h = new Harness();
+        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>()).Returns(Task.FromResult(reply));
+
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_DoesNotReconnectAgain_WhenMultiplexerWasSwappedDuringMembershipCheck()
+    {
+        var h = new Harness();
+        var reply = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
+        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>()).Returns(reply.Task);
+        await h.Connector.ConnectAsync(TestContext.Current.CancellationToken);
+        await h.Connector.ScanStaleEndpointsAsync();
+        h.Clock.Advance(TimeSpan.FromMinutes(5));
+
+        var scan = h.Connector.ScanStaleEndpointsAsync();
+        h.Connector.ForceReconnect();
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        reply.SetResult(ClusterNodesWithoutRetiredNodes);
+        await scan;
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().Equal("Redis.ForcedReconnect");
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_RetriesOnNextScan_WhenRebuildFails()
+    {
+        var h = new Harness(replacementAvailable: false);
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        for (var i = 0; i < 500 && h.Telemetry.Exceptions.Count == 0; i++)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Exceptions.Should().ContainSingle();
+        await Task.Delay(100, TestContext.Current.CancellationToken); // let the failed rebuild release its guard
+
+        await h.Connector.ScanStaleEndpointsAsync();
+        for (var i = 0; i < 500 && h.Telemetry.Exceptions.Count < 2; i++)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken);
+        }
+
+        h.Factory.CreateCount.Should().Be(3);
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointDetected", "Redis.StaleEndpointDetected");
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_IsNoOp_BeforeFirstConnect()
+    {
+        var h = new Harness();
+
+        await h.Connector.ScanStaleEndpointsAsync();
+
+        h.Factory.CreateCount.Should().Be(0);
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public void ParseClusterNodeAddresses_ReadsIpAndHostname_SkipsNoAddr()
+    {
+        const string nodes =
+            "07c3 10.0.0.1:6379@16379,node-a.internal myself,master - 0 0 1 connected 0-5460\n" +
+            "a1b2 10.0.0.2:6379@16379 master - 0 1 2 connected 5461-10922\n" +
+            "c3d4 10.0.0.3:6379@16379,node-c.internal,shard-id=abc master - 0 1 3 connected 10923-16383\n" +
+            "e5f6 10.0.0.4:6379@16379,,shard-id=def master - 0 1 4 connected\n" +
+            "0789 2001:0db8:0:0:0:0:0:1:6379@16379 master - 0 1 5 connected\n" +
+            "dead :0@0 master,fail,noaddr - 0 0 0 disconnected\n" +
+            "\n";
+
+        var addresses = RedisConnector.ParseClusterNodeAddresses(nodes);
+
+        addresses.Should().BeEquivalentTo(["10.0.0.1:6379", "node-a.internal:6379", "10.0.0.2:6379", "10.0.0.3:6379", "node-c.internal:6379", "10.0.0.4:6379", "2001:db8::1:6379"]);
+        addresses.Should().Contain(RedisConnector.FormatEndPoint(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 6379)));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("garbage")]
+    public void ParseClusterNodeAddresses_IsEmpty_ForUnusableReplies(string? reply)
+    {
+        RedisConnector.ParseClusterNodeAddresses(reply).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FormatEndPoint_MatchesClusterNodesAddressShape()
+    {
+        RedisConnector.FormatEndPoint(Live).Should().Be("4.195.18.22:8500");
+        RedisConnector.FormatEndPoint(Seed).Should().Be("redis.example.net:10000");
+    }
+}


### PR DESCRIPTION
## Why

On 2026-09-03 an Azure Managed Redis patch on `redisaas-prd-aue-01` replaced the cluster node VMs and retired two node endpoints (`4.195.18.22:8502` and `:8503`). Two long-lived control-plane pods kept them in the StackExchange.Redis multiplexer and retried them every ~2 s for 19 hours, logging `It was not possible to connect to the redis server(s) <ip:port>/Interactive. ConnectTimeout` at `Error` until a deployment replaced the pods. Traffic was not affected: commands went to the surviving nodes, so nothing in the library reacted.

StackExchange.Redis never forgets a server it has discovered, and only a fresh multiplexer re-reads the topology. Neither existing watchdog covers this case: hang detection needs commands stuck on the primary, and the planned-maintenance probe needs `AzureRedisEvents`, which Microsoft documents as Azure Cache for Redis Basic/Standard/Premium only. Azure Managed Redis does not publish it. Microsoft's guidance for Azure Managed Redis is the ForceReconnect pattern this PR automates.

## What

- `RedisConnector` scans the multiplexer's servers every `StaleEndpointScanInterval` (30 s). A topology-discovered server that stays disconnected for `StaleEndpointThreshold` (5 min) is checked against `CLUSTER NODES` on a connected server. If it is no longer a member, the connector emits `Redis.StaleEndpointDetected` and calls the existing `ForceReconnect()`.
- Configured endpoints are never judged stale. A node that is down but still a cluster member is left to StackExchange.Redis. A non-cluster server (`CLUSTER NODES` fails) is ignored.
- New options, on by default: `EnableStaleEndpointDetection`, `StaleEndpointThreshold`, `StaleEndpointScanInterval`. `RedisConnector` gains a constructor overload that takes a `TimeProvider`; the shipped constructor stays and uses `TimeProvider.System`.
- `RedisHealthCheck` reports `ConnectionMultiplexer.DisconnectedEndPoints` in its data.
- Docs: a "Redis connection self-healing" section in the resilience how-to covering all three watchdogs and the Azure Managed Redis note, settings reference rows, health-check recipe note, sample `appsettings.all.json`, changelog.
- Cluster membership is read with `IServer.ClusterNodesRawAsync()`: a node-local read under the default `AllowAdmin=false`, and a plain string the tests can substitute. The scan only reconnects the multiplexer it inspected, so a reconnect that lands while `CLUSTER NODES` is pending is not followed by a second rebuild.

## Tests

Eleven new tests in `RedisConnectorStaleEndpointTests` drive the scan directly with a fake clock and a substituted `CLUSTER NODES` reply: reconnect on a retired node past the threshold, no action before the threshold, no action when the node is still a member, configured endpoints ignored, non-cluster server ignored, clock reset when the node reconnects in between, no-op before first connect, no second rebuild when the multiplexer is swapped mid-check, plus the `CLUSTER NODES` parser and endpoint formatting.

Full suite: 1554 passed on net8.0 and net10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh