### PR TITLE
build: move the test project to Microsoft.Testing.Platform and xunit.v3 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           /o:"ui"
           /d:sonar.token="${{ env.SONAR_TOKEN }}"
           /d:sonar.host.url="https://sonarcloud.io"
-          /d:sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+          /d:sonar.cs.vscoveragexml.reportsPaths="**/TestResults/**/*.xml"
           /d:sonar.cs.vstest.reportsPaths="**/*.trx"
 
       - name: Restore
@@ -67,7 +67,7 @@ jobs:
         env:
           RUN_REDIS_INTEGRATION_TESTS: '1'
           REDIS_CONNECTION_STRING: 'localhost:6379'
-        run: dotnet test UiPath.Caching.slnx -c Release --no-build --logger trx --results-directory TestResults --collect:"XPlat Code Coverage;Format=opencover"
+        run: dotnet test --solution UiPath.Caching.slnx -c Release --no-build -- --results-directory TestResults --report-xunit-trx --coverage --coverage-output-format xml
 
       - name: SonarQube Cloud end
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         run: dotnet build UiPath.Caching.slnx -c Release --no-restore /p:Version=${{ steps.version.outputs.value }}
 
       - name: Test
-        run: dotnet test UiPath.Caching.slnx -c Release --no-build
+        run: dotnet test --solution UiPath.Caching.slnx -c Release --no-build
 
       - name: FOSSA analyze (upload)
         if: env.FOSSA_API_KEY != ''

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Shared Package Versions -->
-    <xUnit>3.2.2</xUnit>
+    <xUnit>4.0.0</xUnit>
     <AutoFixture>4.18.1</AutoFixture>
     <CloudEvents>2.9.0</CloudEvents>
   </PropertyGroup>
@@ -64,16 +64,14 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <!-- Test related packages -->
     <PackageVersion Include="AwesomeAssertions" Version="9.6.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="xunit.v3" Version="$(xUnit)" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.11.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.27.0" />
     <PackageVersion Include="AutoFixture" Version="$(AutoFixture)" />
     <PackageVersion Include="AutoFixture.Xunit3" Version="4.19.0" />
     <PackageVersion Include="AutoFixture.AutoNSubstitute" Version="$(AutoFixture)" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" />
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="AwesomeAssertions.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
+++ b/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(TargetFrameworks)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
     <SonarQubeTestProject>true</SonarQubeTestProject>
     <!-- AutoFixture.AutoNSubstitute 4.18.1 caps NSubstitute at <6, but 6.2.0 is used and passes; the pin is intentional. -->
@@ -14,19 +15,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit.v3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="AutoFixture.Xunit3" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="coverlet.collector">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="AwesomeAssertions.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />


### PR DESCRIPTION
Replaces #143. xunit.v3 4.0 drops VSTest support, so bumping it alone broke `dotnet test` on the .NET 10 SDK. This PR takes the bump together with the runner change.

## What changes

- `global.json` opts `dotnet test` into the Microsoft.Testing.Platform runner.
- xunit.v3 3.2.2 → 4.0.0. `xunit.runner.visualstudio`, `Microsoft.NET.Test.Sdk` and `coverlet.collector` are removed; the test project sets `OutputType=Exe` as xunit.v3 requires.
- Coverage comes from `Microsoft.Testing.Extensions.CodeCoverage` (18.11.0) as VS coverage XML. Sonar reads it through `sonar.cs.vscoveragexml.reportsPaths` instead of the OpenCover path.
- TRX reports come from xunit's built-in `--report-xunit-trx`; the Sonar `vstest.reportsPaths` glob is unchanged.
- `ci.yml` and `release.yml` use `dotnet test --solution ...` with the MTP flags after `--`.

## Verified locally

Ran the exact CI command on Windows against both target frameworks:

```
dotnet test --solution UiPath.Caching.slnx -c Release --no-build -- --results-directory TestResults --report-xunit-trx --coverage --coverage-output-format xml
```

3222 passed, 0 failed, 21 skipped (Redis integration tests, no local Redis). One `.trx` and one coverage `.xml` per framework landed in the results directory; the coverage file is the `<results><modules>` VS format.

## Notes for reviewers

- IDE test explorers now need MTP support (VS 17.10+ with "Use testing platform server mode", Rider 2024.2+). The VSTest adapter is gone.
- `CONTRIBUTING.md` still says `dotnet build` then `dotnet test`, which remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh
