### PR TITLE
fix(cache): judge stale endpoints from the client's own cluster topology, not an admin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- **Stale endpoint detection works under the default `allowAdmin=false`.** The membership check
+  issued `CLUSTER NODES`, which StackExchange.Redis refuses client-side unless admin mode is on, so on
+  a default connection every scan recorded a `RedisCommandException` and never reconnected. The scan
+  now refreshes the client's own cluster topology (`IConnectionMultiplexer.ConfigureAsync`, whose
+  `CLUSTER NODES` is an internal call) and reads the `ClusterConfiguration` it records on the
+  configured endpoints, judging only once the refresh has replaced it. When a refreshed node has none
+  on three consecutive refreshes — a non-cluster server, or a Redis user that may not run
+  `CLUSTER NODES` — the scan emits one `Redis.StaleEndpointScanDisabled` event and stops, instead of
+  reporting the same failure every interval. A down node the topology still lists is re-checked only
+  once per threshold and reported once through `Redis.StaleEndpointStillAMember`; a refresh that keeps
+  throwing backs off exponentially, up to an hour between attempts.
 - **`RefreshAsync` on Redis reported nothing.** Both Redis caches sent their standalone
   `KEYEXPIRE`/`PERSIST` fire-and-forget, so the call returned `false` whether the refresh succeeded, failed
   or the key did not exist, the server's reply was never seen — a rejected command was neither logged nor

--- a/docs/how-to/resilience.md
+++ b/docs/how-to/resilience.md
@@ -423,7 +423,7 @@ old one (`Redis.ForcedReconnect` event, `OnReconnected` raised).
 |---|---|---|
 | Hang detection | More than 100 commands awaiting a reply on the primary with no read or write for `LastWrite/ReadIntervalThresholdMilliseconds` | `EnableHangDetection`, `HangDetectionDueTime`, `HangDetectionPeriod` |
 | Planned maintenance | `NodeMaintenanceStarting` on the `AzureRedisEvents` channel; probes with a write every second for 10 minutes and reconnects on failure | `PlannedMaintenanceEnabled` |
-| Stale endpoint detection | A topology-discovered node has been disconnected for `StaleEndpointThreshold` and is no longer listed by `CLUSTER NODES` | `EnableStaleEndpointDetection`, `StaleEndpointThreshold`, `StaleEndpointScanInterval` |
+| Stale endpoint detection | A topology-discovered node has been disconnected for `StaleEndpointThreshold` and is no longer in the cluster topology the client refreshes | `EnableStaleEndpointDetection`, `StaleEndpointThreshold`, `StaleEndpointScanInterval` |
 
 **Stale endpoints** are the clustered-cache failure mode. StackExchange.Redis discovers the
 node addresses behind the endpoint you configure and then never forgets one. When a provider
@@ -432,9 +432,29 @@ the old ones — the retired address stays in the multiplexer and is retried on 
 policy forever, logging `It was not possible to connect to the redis server(s) <ip:port>` at
 `Error` every few seconds. Commands still flow to the surviving nodes, so nothing else trips.
 The scan only judges endpoints the multiplexer discovered (never the ones in your connection
-string), only after they have been down for the threshold, and only when a connected server
-confirms the node is gone. A node that is down but still a cluster member is left alone. On a
-non-cluster server the membership query fails and the scan does nothing.
+string), only after they have been down for the threshold, and only when the cluster topology
+confirms the node is gone. The membership check re-runs the client's own connection handshake
+(`IConnectionMultiplexer.ConfigureAsync`) and reads the `ClusterConfiguration` it records on the
+configured endpoints, the only ones that handshake refreshes. The configuration counts only if the
+refresh replaced it, since a landed re-read installs a new instance; if it did not, or the refresh
+was skipped because another reconfiguration was running, or no configured endpoint is connected,
+the scan judges nothing and tries again next interval. That handshake issues `CLUSTER NODES` as an
+internal call, so the scan works under the default `allowAdmin=false` and needs no permission
+beyond what StackExchange.Redis already needs to run against a cluster. A node the cluster still
+lists as reachable is left alone. One the cluster has flagged `fail` is treated like a departed
+one: the client drops such nodes from the topology it exposes and from the endpoints it dials, so
+a rebuilt connection would not retry it either. A down node the topology confirms as a member — one
+unreachable from this client but healthy in the cluster — is asked about again only once per
+`StaleEndpointThreshold`, and its first confirmation emits one `Redis.StaleEndpointStillAMember`
+event naming the endpoints, so the condition is visible without a topology refresh every interval.
+When the refresh itself throws (a handshake that never completes, say), the exception is tracked
+and the scan backs off, doubling the intervals it skips up to an hour, so a persistent fault yields
+a handful of tracked exceptions a day rather than one per interval.
+When a refreshed node reports no cluster configuration — a non-cluster server, or a Redis user
+that may not run `CLUSTER NODES` — membership can never be judged: after three consecutive such
+refreshes, so that a single lost topology reply is retried instead, the scan emits one
+`Redis.StaleEndpointScanDisabled` event and stops for the lifetime of the connector, rather than
+reporting the same failure every interval.
 
 **Which Azure offering sends maintenance events.** The `AzureRedisEvents` channel exists on
 Azure Cache for Redis Basic, Standard and Premium only. Azure Managed Redis (`*.redis.azure.net`)

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -63,7 +63,7 @@ Every binding-visible property on every shipped options class, with shipped defa
 | `DefaultVersion` | `string?` | `"6.0"` | App-wide | Redis server version hint passed to StackExchange.Redis for command compatibility. |
 | `HangDetectionDueTime` | `TimeSpan?` | `null` | App-wide | Delay before the first hang-detection check; `null` = 30 s library default. |
 | `HangDetectionPeriod` | `TimeSpan?` | `null` | App-wide | Period between hang-detection checks; `null` = library default. |
-| `EnableStaleEndpointDetection` | `bool` | `true` | App-wide | Rebuild the connection when a cluster node the multiplexer discovered has left the cluster but is still being retried (see [Redis connection self-healing](../how-to/resilience.md#redis-connection-self-healing)). |
+| `EnableStaleEndpointDetection` | `bool` | `true` | App-wide | Rebuild the connection when a cluster node the multiplexer discovered has left the cluster but is still being retried (see [Redis connection self-healing](../how-to/resilience.md#redis-connection-self-healing)). Works under the default `allowAdmin=false`; emits one `Redis.StaleEndpointScanDisabled` event and stops when no refreshed node reports a cluster configuration. |
 | `StaleEndpointThreshold` | `TimeSpan` | `00:05:00` | App-wide | How long a discovered endpoint must stay disconnected before its cluster membership is checked; non-positive falls back to the default. |
 | `StaleEndpointScanInterval` | `TimeSpan` | `00:00:30` | App-wide | Period between stale-endpoint scans; non-positive falls back to the default. |
 | `FailFastBacklogPolicy` | `bool?` | `null` | App-wide | `null` = library default; `true` = fail immediately when the command backlog is full. |

--- a/src/UiPath.Caching/Redis/ClusterTopologyReader.cs
+++ b/src/UiPath.Caching/Redis/ClusterTopologyReader.cs
@@ -1,0 +1,32 @@
+using System.Net;
+
+namespace UiPath.Caching.Redis;
+
+/// <summary>Cluster membership as the client's own topology handshake last recorded it on a node.</summary>
+internal interface IClusterTopologyReader
+{
+    /// <returns>The configuration the client last recorded on the node, a new instance each time it re-reads one; null when the node has none.</returns>
+    object? GetConfiguration(IServer server);
+
+    HashSet<EndPoint> GetMembers(object configuration);
+}
+
+/// <summary>What a topology refresh reported; when conclusive, a null <see cref="Members"/> means membership can never be judged.</summary>
+internal readonly record struct ClusterMembership(bool Conclusive, HashSet<EndPoint>? Members)
+{
+    public static ClusterMembership Inconclusive => default;
+}
+
+[ExcludeFromCodeCoverage(Justification = "ClusterConfiguration has no public constructor; only a live cluster handshake populates it.")]
+internal sealed class ClusterConfigurationReader : IClusterTopologyReader
+{
+    public static readonly ClusterConfigurationReader Instance = new();
+
+    public object? GetConfiguration(IServer server) => server.ClusterConfiguration;
+
+    public HashSet<EndPoint> GetMembers(object configuration) =>
+        ((ClusterConfiguration)configuration).Nodes
+            .Where(node => node.EndPoint is not null && !node.IsHandshake) // the client does not dial nodes still joining, so a rebuilt connection would not retry them
+            .Select(node => node.EndPoint!)
+            .ToHashSet();
+}

--- a/src/UiPath.Caching/Redis/RedisConnector.cs
+++ b/src/UiPath.Caching/Redis/RedisConnector.cs
@@ -7,6 +7,12 @@ namespace UiPath.Caching.Redis;
 
 public sealed class RedisConnector : IRedisConnector
 {
+    /// <summary>Consecutive refreshes a node may report no configuration before the scan concludes it never will.</summary>
+    internal const int NullTopologyRefreshLimit = 3;
+
+    /// <summary>Most scan intervals skipped after a failing refresh: an hour at the default interval.</summary>
+    internal const int MaxScanBackoff = 120;
+
     private readonly RedisConnectionOptions _redisOptions;
     private readonly ICachingTelemetryProvider _telemetryProvider;
     private readonly IRedisConfigurationOptionsProvider _redisConfigurationOptionsProvider;
@@ -17,13 +23,20 @@ public sealed class RedisConnector : IRedisConnector
     private readonly TimeSpan _staleEndpointThreshold;
     private readonly TimeProvider _clock;
     private readonly Dictionary<EndPoint, long> _disconnectedSince = [];
+    private readonly Dictionary<EndPoint, long> _memberConfirmedAt = [];
+    private readonly IClusterTopologyReader _topologyReader;
     private readonly Lazy<Version> _version;
     private readonly object _swapLock = new();
 
     private volatile Lazy<Task<IConnectionMultiplexer>> _lazyCacheConnectionMultiplexer;
     private volatile bool _disposed;
+    private volatile bool _staleScanDisabled;
     private int _reconnecting;
     private int _staleScanRunning;
+    private int _nullTopologyRefreshes;
+    private IConnectionMultiplexer? _nullTopologyMultiplexer;
+    private int _scanFailures;
+    private int _scansToSkip;
     private ReadWriteStatus? _lastMasterMetrics;
 
     public RedisConnector(ICachingTelemetryProvider telemetryProvider,
@@ -41,6 +54,17 @@ public sealed class RedisConnector : IRedisConnector
         IOptions<RedisConnectionOptions> redisOptions,
         IEnumerable<IRedisConnectionConfigurator>? configurators,
         TimeProvider? clock)
+        : this(telemetryProvider, redisConfigurationOptionsProvider, connectionMultiplexerFactory, redisOptions, configurators, clock, null)
+    {
+    }
+
+    internal RedisConnector(ICachingTelemetryProvider telemetryProvider,
+        IRedisConfigurationOptionsProvider redisConfigurationOptionsProvider,
+        IConnectionMultiplexerFactory connectionMultiplexerFactory,
+        IOptions<RedisConnectionOptions> redisOptions,
+        IEnumerable<IRedisConnectionConfigurator>? configurators,
+        TimeProvider? clock,
+        IClusterTopologyReader? topologyReader)
     {
         _redisOptions = redisOptions.Value;
 
@@ -51,6 +75,7 @@ public sealed class RedisConnector : IRedisConnector
         _connectionMultiplexerFactory = connectionMultiplexerFactory;
         _configurators = configurators;
         _clock = clock ?? TimeProvider.System;
+        _topologyReader = topologyReader ?? ClusterConfigurationReader.Instance;
         if (_redisOptions.EnableHangDetection)
         {
             var hangDetectionDueTime = _redisOptions.HangDetectionDueTime ?? TimeSpan.FromSeconds(30);
@@ -337,7 +362,7 @@ public sealed class RedisConnector : IRedisConnector
     /// <summary>Only topology-discovered endpoints can go stale; configured ones are left to StackExchange.Redis.</summary>
     internal async Task ScanStaleEndpointsAsync()
     {
-        if (_disposed || Volatile.Read(ref _reconnecting) > 0)
+        if (_disposed || _staleScanDisabled || Volatile.Read(ref _reconnecting) > 0)
         {
             return;
         }
@@ -355,8 +380,26 @@ public sealed class RedisConnector : IRedisConnector
 
         try
         {
+            if (_scansToSkip > 0)
+            {
+                _scansToSkip--;
+                return;
+            }
+
             var stale = await FindStaleEndpointsAsync(lazy.Value.Result).ConfigureAwait(false);
-            if (stale.Count == 0 || !ReferenceEquals(_lazyCacheConnectionMultiplexer, lazy))
+            _scanFailures = 0;
+            if (!ReferenceEquals(_lazyCacheConnectionMultiplexer, lazy))
+            {
+                return;
+            }
+
+            if (stale is null)
+            {
+                DisableStaleEndpointScan(lazy);
+                return;
+            }
+
+            if (stale.Count == 0)
             {
                 return;
             }
@@ -371,6 +414,7 @@ public sealed class RedisConnector : IRedisConnector
         }
         catch (Exception ex)
         {
+            _scansToSkip = Math.Min(1 << Math.Min(++_scanFailures, 7), MaxScanBackoff); // a handshake that never completes fails every refresh; back off instead of tracking it every interval
             _telemetryProvider.TrackException(ex);
         }
         finally
@@ -379,7 +423,8 @@ public sealed class RedisConnector : IRedisConnector
         }
     }
 
-    private async Task<List<EndPoint>> FindStaleEndpointsAsync(IConnectionMultiplexer multiplexer)
+    /// <returns>Null when no connected node carries a cluster configuration, so membership can never be judged.</returns>
+    private async Task<List<EndPoint>?> FindStaleEndpointsAsync(IConnectionMultiplexer multiplexer)
     {
         var now = _clock.GetTimestamp();
         var configured = multiplexer.GetEndPoints(configuredOnly: true);
@@ -400,6 +445,7 @@ public sealed class RedisConnector : IRedisConnector
         foreach (var endpoint in _disconnectedSince.Keys.Where(e => !disconnected.Exists(s => s.EndPoint.Equals(e))).ToArray())
         {
             _disconnectedSince.Remove(endpoint);
+            _memberConfirmedAt.Remove(endpoint);
         }
 
         var overdue = new List<EndPoint>();
@@ -409,7 +455,7 @@ public sealed class RedisConnector : IRedisConnector
             {
                 _disconnectedSince[endpoint] = now;
             }
-            else if (_clock.GetElapsedTime(since, now) >= _staleEndpointThreshold)
+            else if (_clock.GetElapsedTime(since, now) >= _staleEndpointThreshold && !IsRecentlyConfirmedMember(endpoint, now))
             {
                 overdue.Add(endpoint);
             }
@@ -420,83 +466,111 @@ public sealed class RedisConnector : IRedisConnector
             return [];
         }
 
-        var members = await GetClusterMemberAddressesAsync(connected).ConfigureAwait(false);
-        return members is null ? [] : overdue.Where(ep => !members.Contains(FormatEndPoint(ep))).ToList();
-    }
-
-    private static async Task<HashSet<string>?> GetClusterMemberAddressesAsync(IServer server)
-    {
-        try
+        var membership = await RefreshClusterMembershipAsync(multiplexer).ConfigureAwait(false);
+        if (!membership.Conclusive)
         {
-            var members = ParseClusterNodeAddresses(await server.ClusterNodesRawAsync().ConfigureAwait(false));
-            return members.Count == 0 ? null : members; // a real reply lists at least the answering node
+            return [];
         }
-        catch (RedisServerException ex) when (IsNotACluster(ex))
+
+        if (membership.Members is null)
         {
             return null;
         }
+
+        var confirmed = overdue.Where(membership.Members.Contains).ToList();
+        RecordConfirmedMembers(confirmed, now);
+        return overdue.Except(confirmed).ToList();
     }
 
-    private static bool IsNotACluster(RedisServerException ex) =>
-        ex.Message.Contains("cluster support disabled", StringComparison.OrdinalIgnoreCase)
-        || ex.Message.StartsWith("ERR unknown command", StringComparison.OrdinalIgnoreCase)
-        || ex.Message.StartsWith("ERR unknown subcommand", StringComparison.OrdinalIgnoreCase);
-
-    internal static HashSet<string> ParseClusterNodeAddresses(string? clusterNodes)
+    /// <summary>A member the cluster still lists is asked about again only once per threshold, and reported the first time.</summary>
+    private void RecordConfirmedMembers(List<EndPoint> confirmed, long now)
     {
-        var addresses = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (string.IsNullOrWhiteSpace(clusterNodes))
+        var firstTime = confirmed.Where(endpoint => !_memberConfirmedAt.ContainsKey(endpoint)).ToList();
+        foreach (var endpoint in confirmed)
         {
-            return addresses;
+            _memberConfirmedAt[endpoint] = now;
         }
 
-        foreach (var line in clusterNodes.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        if (firstTime.Count > 0)
         {
-            AddNodeAddresses(line, addresses);
-        }
-
-        return addresses;
-    }
-
-    private static void AddNodeAddresses(string line, HashSet<string> addresses)
-    {
-        var fields = line.Split(' ');
-        if (fields.Length < 3 || fields[2].Contains("noaddr", StringComparison.OrdinalIgnoreCase))
-        {
-            return;
-        }
-
-        // <ip:port@cport[,hostname[,aux=value...]]>
-        var address = fields[1].AsSpan();
-        var at = address.IndexOf('@');
-        var hostPort = at < 0 ? address : address[..at];
-        var portSeparator = hostPort.LastIndexOf(':');
-        if (portSeparator < 0)
-        {
-            return;
-        }
-
-        var port = hostPort[(portSeparator + 1)..];
-        addresses.Add(IPAddress.TryParse(hostPort[..portSeparator], out var ip) ? $"{ip}:{port}" : hostPort.ToString()); // canonical spelling, as FormatEndPoint produces
-        var hostname = HostnameSegment(at < 0 ? default : address[(at + 1)..]);
-        if (!hostname.IsEmpty)
-        {
-            addresses.Add($"{hostname}:{port}");
+            _telemetryProvider.TrackEvent(
+                "Redis.StaleEndpointStillAMember",
+                [
+                    new("EndPoints", string.Join(";", firstTime.Select(FormatEndPoint))),
+                    new("Threshold", _staleEndpointThreshold.ToString()),
+                ]);
         }
     }
 
-    /// <summary>The hostname is the first comma-separated segment after the cluster port; anything after it is auxiliary.</summary>
-    private static ReadOnlySpan<char> HostnameSegment(ReadOnlySpan<char> afterAt)
+    private bool IsRecentlyConfirmedMember(EndPoint endpoint, long now) =>
+        _memberConfirmedAt.TryGetValue(endpoint, out var confirmedAt) && _clock.GetElapsedTime(confirmedAt, now) < _staleEndpointThreshold;
+
+    internal async Task<ClusterMembership> RefreshClusterMembershipAsync(IConnectionMultiplexer multiplexer)
     {
-        var comma = afterAt.IndexOf(',');
-        if (comma < 0)
+        // A non-initial reconfigure re-handshakes the configured endpoints only, so only their configuration can become current.
+        var configured = multiplexer.GetEndPoints(configuredOnly: true);
+        var candidates = multiplexer.GetServers()
+            .Where(server => server.IsConnected && Array.IndexOf(configured, server.EndPoint) >= 0)
+            .Select(server => (Server: server, Before: _topologyReader.GetConfiguration(server)))
+            .ToList();
+
+        // The client's own handshake reads CLUSTER NODES as an internal call, so AllowAdmin does not apply; false means another reconfiguration held the guard.
+        if (candidates.Count == 0 || !await multiplexer.ConfigureAsync().ConfigureAwait(false))
         {
-            return default;
+            return ClusterMembership.Inconclusive;
         }
 
-        var hostname = afterAt[(comma + 1)..];
-        var next = hostname.IndexOf(',');
-        return next < 0 ? hostname : hostname[..next];
+        var unchanged = false;
+        var neverConfigured = false;
+        foreach (var (server, before) in candidates)
+        {
+            var after = _topologyReader.GetConfiguration(server);
+            if (after is null)
+            {
+                neverConfigured |= before is null && server.IsConnected;
+            }
+            else if (ReferenceEquals(after, before))
+            {
+                unchanged = true; // a landed re-read installs a new instance, so the same one means this node's refresh failed
+            }
+            else if (server.IsConnected)
+            {
+                _nullTopologyRefreshes = 0;
+                return new(Conclusive: true, _topologyReader.GetMembers(after));
+            }
+        }
+
+        if (unchanged || !neverConfigured)
+        {
+            _nullTopologyRefreshes = 0;
+            return ClusterMembership.Inconclusive;
+        }
+
+        // A node with no configuration may have lost only the topology reply; a persistent absence means it cannot answer it.
+        // The streak belongs to the multiplexer it was observed on, so a rebuilt one starts over.
+        if (!ReferenceEquals(_nullTopologyMultiplexer, multiplexer))
+        {
+            _nullTopologyMultiplexer = multiplexer;
+            _nullTopologyRefreshes = 0;
+        }
+
+        return ++_nullTopologyRefreshes >= NullTopologyRefreshLimit ? new(Conclusive: true, Members: null) : ClusterMembership.Inconclusive;
+    }
+
+    private void DisableStaleEndpointScan(Lazy<Task<IConnectionMultiplexer>> judged)
+    {
+        lock (_swapLock)
+        {
+            if (_disposed || !ReferenceEquals(_lazyCacheConnectionMultiplexer, judged))
+            {
+                return;
+            }
+
+            _staleScanDisabled = true;
+        }
+
+        _staleEndpointTimer?.Dispose();
+        _telemetryProvider.TrackEvent("Redis.StaleEndpointScanDisabled", [new("Reason", "NoClusterConfiguration")]);
     }
 
     internal static string FormatEndPoint(EndPoint endPoint) => endPoint switch

--- a/tests/UiPath.Caching.Tests/Redis/RedisConnectorIntegrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConnectorIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Microsoft.Extensions.Logging.Abstractions;
 using StackExchange.Redis;
 using UiPath.Caching.Redis;
@@ -48,6 +49,39 @@ public class RedisConnectorIntegrationTests(RedisContainerFixture fixture)
         connector.IsConnected.Should().BeTrue();
         await connector.Database.StringSetAsync("k2", "v2");
         (await connector.Database.StringGetAsync("k2")).ToString().Should().Be("v2");
+    }
+
+    [Fact]
+    public async Task RefreshClusterMembership_ReachesTheServer_UnderTheDefaultConnectionString()
+    {
+        Assert.SkipUnless(fixture.Enabled, "Set RUN_REDIS_INTEGRATION_TESTS=1 (Docker required) to run.");
+        Assert.SkipWhen(ConfigurationOptions.Parse(fixture.ConnectionString).AllowAdmin, "The point is the default allowAdmin=false.");
+
+        using var connector = NewConnector();
+        await using var multiplexer = await ConnectionMultiplexer.ConnectAsync(fixture.ConnectionString);
+        await using var observer = await ConnectionMultiplexer.ConnectAsync(fixture.ConnectionString + ",allowAdmin=true");
+        var clusterCallsBefore = await ClusterCommandCallsAsync(observer);
+
+        var memberships = new List<ClusterMembership>();
+        for (var refreshes = 0; refreshes < RedisConnector.NullTopologyRefreshLimit; refreshes++)
+        {
+            memberships.Add(await connector.RefreshClusterMembershipAsync(multiplexer));
+        }
+
+        memberships.Take(RedisConnector.NullTopologyRefreshLimit - 1).Should().AllSatisfy(m => m.Conclusive.Should().BeFalse("one missing configuration could still be a lost reply"));
+        memberships[^1].Conclusive.Should().BeTrue();
+        memberships[^1].Members.Should().BeNull("a standalone server has no cluster configuration");
+        (await ClusterCommandCallsAsync(observer) - clusterCallsBefore).Should().BeGreaterThanOrEqualTo(
+            RedisConnector.NullTopologyRefreshLimit, "each refresh must carry the client's own CLUSTER NODES to the server");
+    }
+
+    /// <summary>Server-side count of CLUSTER commands, which the client only ever sends from its handshake.</summary>
+    private static async Task<long> ClusterCommandCallsAsync(ConnectionMultiplexer observer)
+    {
+        var sections = await observer.GetServer(observer.GetEndPoints()[0]).InfoAsync("commandstats");
+        return sections.SelectMany(section => section)
+            .Where(stat => stat.Key.StartsWith("cmdstat_cluster", StringComparison.OrdinalIgnoreCase))
+            .Sum(stat => long.Parse(stat.Value.Split(',')[0]["calls=".Length..], CultureInfo.InvariantCulture));
     }
 
     [Fact]

--- a/tests/UiPath.Caching.Tests/Redis/RedisConnectorStaleEndpointTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConnectorStaleEndpointTests.cs
@@ -7,10 +7,6 @@ namespace UiPath.Caching.Tests.Redis;
 
 public class RedisConnectorStaleEndpointTests
 {
-    private const string ClusterNodesWithoutRetiredNodes =
-        "07c3 4.195.18.22:8500@18500 myself,master - 0 0 1 connected 0-8191\n" +
-        "a1b2 4.195.18.22:8501@18501 master - 0 1 2 connected 8192-16383\n";
-
     private static readonly DnsEndPoint Seed = new("redis.example.net", 10000);
     private static readonly IPEndPoint Live = new(IPAddress.Parse("4.195.18.22"), 8500);
     private static readonly IPEndPoint Retired = new(IPAddress.Parse("4.195.18.22"), 8502);
@@ -81,9 +77,32 @@ public class RedisConnectorStaleEndpointTests
         public void TrackEvent(string eventName, ReadOnlySpan<KeyValuePair<string, string>> properties = default, ReadOnlySpan<KeyValuePair<string, double>> metrics = default) => Events.Add(eventName);
     }
 
-#pragma warning disable CS0618 // the replacement constructor takes RedisErrorKind, which is still experimental (SER007)
-    private static RedisServerException ServerError(string message) => new(message);
-#pragma warning restore CS0618
+    private sealed class FakeTopology : IClusterTopologyReader
+    {
+        private object _configuration = new();
+
+        public HashSet<EndPoint>? Members { get; set; }
+        public bool RefreshLands { get; set; } = true;
+        public int Reads { get; private set; }
+
+        public object? GetConfiguration(IServer server) => Members is null ? null : _configuration;
+
+        public HashSet<EndPoint> GetMembers(object configuration)
+        {
+            Reads++;
+            return Members!;
+        }
+
+        public Task<bool> Refreshed()
+        {
+            if (RefreshLands)
+            {
+                _configuration = new();
+            }
+
+            return Task.FromResult(true);
+        }
+    }
 
     private sealed class Harness
     {
@@ -91,19 +110,22 @@ public class RedisConnectorStaleEndpointTests
         public RecordingTelemetry Telemetry { get; } = new();
         public IConnectionMultiplexer Multiplexer { get; } = Substitute.For<IConnectionMultiplexer>();
         public IConnectionMultiplexer Replacement { get; } = Substitute.For<IConnectionMultiplexer>();
-        public IServer LiveServer { get; } = Server(Live, connected: true);
+        public IServer LiveServer { get; }
         public IServer RetiredServer { get; } = Server(Retired, connected: false);
+        public FakeTopology Topology { get; } = new();
         public SequenceFactory Factory { get; }
         public RedisConnector Connector { get; }
         public TaskCompletionSource OldDisposed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
-        public Harness(string clusterNodes = ClusterNodesWithoutRetiredNodes, bool retiredIsConfigured = false, bool replacementAvailable = true, bool timerDriven = false)
+        public Harness(bool retiredIsMember = false, bool clusterConfigurationKnown = true, bool retiredIsConfigured = false, bool replacementAvailable = true, bool timerDriven = false, bool connectedNodeIsConfigured = true)
         {
+            LiveServer = Server(connectedNodeIsConfigured ? Seed : Live, connected: true); // only the configured endpoints are re-handshaked by the refresh
+            Topology.Members = clusterConfigurationKnown ? (retiredIsMember ? [Live, Retired] : [Live]) : null;
             Multiplexer.GetEndPoints(true).Returns(retiredIsConfigured ? [Seed, Retired] : [Seed]);
             Multiplexer.GetServers().Returns([LiveServer, RetiredServer]);
+            Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => Topology.Refreshed());
             Multiplexer.CloseAsync(Arg.Any<bool>()).Returns(Task.CompletedTask);
             Multiplexer.When(m => m.Dispose()).Do(_ => OldDisposed.TrySetResult());
-            LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>()).Returns(Task.FromResult<string?>(clusterNodes));
 
             Factory = replacementAvailable ? new SequenceFactory(Multiplexer, Replacement) : new SequenceFactory(Multiplexer);
             var options = Options.Create(new RedisConnectionOptions
@@ -115,7 +137,7 @@ public class RedisConnectorStaleEndpointTests
                 StaleEndpointScanInterval = TimeSpan.FromSeconds(30),
             });
             var optionsProvider = new RedisConfigurationOptionsProvider(NullLoggerFactory.Instance, options);
-            Connector = new RedisConnector(Telemetry, optionsProvider, Factory, options, configurators: null, clock: Clock);
+            Connector = new RedisConnector(Telemetry, optionsProvider, Factory, options, configurators: null, clock: Clock, topologyReader: Topology);
         }
 
         public async Task ScanTwiceAcrossThresholdAsync()
@@ -146,6 +168,7 @@ public class RedisConnectorStaleEndpointTests
         h.Factory.CreateCount.Should().Be(2);
         h.Telemetry.Events.Should().ContainInOrder("Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
         h.Telemetry.Exceptions.Should().BeEmpty();
+        await h.Multiplexer.Received(1).ConfigureAsync(Arg.Any<TextWriter?>());
         h.Connector.Dispose();
     }
 
@@ -177,19 +200,64 @@ public class RedisConnectorStaleEndpointTests
 
         h.Factory.CreateCount.Should().Be(1);
         h.Telemetry.Events.Should().BeEmpty();
-        await h.LiveServer.DidNotReceive().ClusterNodesRawAsync(Arg.Any<CommandFlags>());
+        await h.Multiplexer.DidNotReceive().ConfigureAsync(Arg.Any<TextWriter?>());
         h.Connector.Dispose();
     }
 
     [Fact]
-    public async Task Scan_DoesNothing_WhenDownEndpointIsStillAClusterMember()
+    public async Task Scan_ReportsAStillListedMemberOnce_AndAsksAgainOnlyAfterTheThreshold()
     {
-        var h = new Harness(ClusterNodesWithoutRetiredNodes + "c3d4 4.195.18.22:8502@18502 slave 07c3 0 1 1 disconnected\n");
+        var h = new Harness(retiredIsMember: true);
 
         await h.ScanTwiceAcrossThresholdAsync();
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointStillAMember");
+        for (var i = 0; i < 4; i++)
+        {
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync();
+        }
+        await h.Multiplexer.Received(1).ConfigureAsync(Arg.Any<TextWriter?>());
+
+        h.Clock.Advance(TimeSpan.FromMinutes(3));
+        await h.Connector.ScanStaleEndpointsAsync();
 
         h.Factory.CreateCount.Should().Be(1);
-        h.Telemetry.Events.Should().BeEmpty();
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointStillAMember");
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        await h.Multiplexer.Received(2).ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_ForgetsAConfirmedMember_OnceItReconnects()
+    {
+        var h = new Harness(retiredIsMember: true);
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        h.RetiredServer.IsConnected.Returns(true);
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync();
+        h.RetiredServer.IsConnected.Returns(false);
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointStillAMember", "Redis.StaleEndpointStillAMember");
+        await h.Multiplexer.Received(2).ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_ReconnectsAfterAll_WhenAConfirmedMemberIsLaterRemoved()
+    {
+        var h = new Harness(retiredIsMember: true);
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        h.Topology.Members = [Live];
+        h.Clock.Advance(TimeSpan.FromMinutes(5));
+        await h.Connector.ScanStaleEndpointsAsync();
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointStillAMember", "Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
         h.Connector.Dispose();
     }
 
@@ -201,38 +269,243 @@ public class RedisConnectorStaleEndpointTests
         await h.ScanTwiceAcrossThresholdAsync();
 
         h.Factory.CreateCount.Should().Be(1);
-        await h.LiveServer.DidNotReceive().ClusterNodesRawAsync(Arg.Any<CommandFlags>());
+        await h.Multiplexer.DidNotReceive().ConfigureAsync(Arg.Any<TextWriter?>());
         h.Connector.Dispose();
     }
 
-    [Theory]
-    [InlineData("ERR This instance has cluster support disabled")]
-    [InlineData("ERR unknown command 'CLUSTER'")]
-    public async Task Scan_DoesNothing_WhenServerIsNotACluster(string error)
+    [Fact]
+    public async Task Scan_DisablesItself_OnlyAfterANodeKeepsReportingNoConfiguration()
     {
-        var h = new Harness();
-        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>())
-            .Returns<string?>(_ => throw ServerError(error));
+        var h = new Harness(clusterConfigurationKnown: false);
 
         await h.ScanTwiceAcrossThresholdAsync();
+        for (var refreshes = 1; refreshes < RedisConnector.NullTopologyRefreshLimit; refreshes++)
+        {
+            h.Telemetry.Events.Should().BeEmpty();
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync();
+        }
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointScanDisabled");
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync();
 
         h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        await h.Multiplexer.Received(RedisConnector.NullTopologyRefreshLimit).ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Timer_StopsFiring_OnceTheScanIsDisabled()
+    {
+        var h = new Harness(clusterConfigurationKnown: false, timerDriven: true);
+        await h.Connector.ConnectAsync(TestContext.Current.CancellationToken);
+
+        h.Clock.Advance(TimeSpan.FromMinutes(5) + TimeSpan.FromSeconds(30) * RedisConnector.NullTopologyRefreshLimit); // the first refresh is at 5:30, one more per tick
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointScanDisabled");
+        h.Clock.Advance(TimeSpan.FromMinutes(10));
+
+        h.Factory.CreateCount.Should().Be(1);
+        await h.Multiplexer.Received(RedisConnector.NullTopologyRefreshLimit).ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_RetriesNextInterval_WhenTheRefreshWasSkipped()
+    {
+        var h = new Harness();
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => Task.FromResult(false), _ => h.Topology.Refreshed());
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        h.Topology.Reads.Should().Be(0);
+        h.Telemetry.Events.Should().BeEmpty();
+
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync();
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().ContainInOrder("Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
         h.Telemetry.Exceptions.Should().BeEmpty();
         h.Connector.Dispose();
     }
 
     [Fact]
-    public async Task Scan_TracksOtherServerErrors_WithoutReconnecting()
+    public async Task Scan_DoesNotJudge_WhenOnlyDiscoveredNodesAreConnected()
+    {
+        var h = new Harness(connectedNodeIsConfigured: false);
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Topology.Reads.Should().Be(0);
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        await h.Multiplexer.DidNotReceive().ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_DoesNotJudge_UntilTheRefreshReplacesTheConfiguration()
     {
         var h = new Harness();
-        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>())
-            .Returns<string?>(_ => throw ServerError("NOPERM this user has no permissions to run the 'cluster|nodes' command"));
+        h.Topology.RefreshLands = false;
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync();
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Topology.Reads.Should().Be(0);
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        await h.Multiplexer.Received(2).ConfigureAsync(Arg.Any<TextWriter?>());
+
+        h.Topology.RefreshLands = true;
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync();
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().ContainInOrder("Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_DoesNotJudge_WhenTheRefreshedNodeDroppedAfterInstallingATopology()
+    {
+        var h = new Harness();
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(async _ =>
+        {
+            await h.Topology.Refreshed();
+            h.LiveServer.IsConnected.Returns(false);
+            return true;
+        });
 
         await h.ScanTwiceAcrossThresholdAsync();
 
         h.Factory.CreateCount.Should().Be(1);
+        h.Topology.Reads.Should().Be(0);
         h.Telemetry.Events.Should().BeEmpty();
-        h.Telemetry.Exceptions.Should().ContainSingle().Which.Should().BeOfType<RedisServerException>();
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_StartsTheNullStreakOver_OnARebuiltMultiplexer()
+    {
+        var h = new Harness(clusterConfigurationKnown: false);
+        h.Replacement.GetEndPoints(true).Returns([Seed]);
+        h.Replacement.GetServers().Returns([h.LiveServer, h.RetiredServer]);
+        h.Replacement.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => h.Topology.Refreshed());
+
+        await h.ScanTwiceAcrossThresholdAsync();
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync(); // two null refreshes on the first multiplexer
+        h.Connector.ForceReconnect();
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        for (var i = 0; i < 500 && !h.Replacement.ReceivedCalls().Any(c => c.GetMethodInfo().Name == nameof(IConnectionMultiplexer.ConfigureAsync)); i++)
+        {
+            await Task.Delay(10, TestContext.Current.CancellationToken); // the rebuild releases its guard just after disposing the old multiplexer
+            await h.Connector.ScanStaleEndpointsAsync();
+        }
+
+        for (var refreshes = 1; refreshes < RedisConnector.NullTopologyRefreshLimit; refreshes++)
+        {
+            h.Telemetry.Events.Should().Equal("Redis.ForcedReconnect");
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync();
+        }
+
+        h.Telemetry.Events.Should().Equal("Redis.ForcedReconnect", "Redis.StaleEndpointScanDisabled");
+        await h.Replacement.Received(RedisConnector.NullTopologyRefreshLimit).ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_BacksOffExponentially_WhileTheRefreshKeepsFailing_AndRecovers()
+    {
+        var h = new Harness();
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns<Task<bool>>(_ => throw new RedisTimeoutException(CommandFlags.None, "slow", CommandStatus.Unknown));
+
+        await h.ScanTwiceAcrossThresholdAsync(); // attempt 1; the next two intervals are skipped
+        for (var i = 0; i < 11; i++)
+        {
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync(); // attempts 2 and 3 land after 2 and then 4 skipped intervals
+        }
+
+        h.Telemetry.Exceptions.Should().HaveCount(3).And.AllBeOfType<RedisTimeoutException>();
+        await h.Multiplexer.Received(3).ConfigureAsync(Arg.Any<TextWriter?>());
+        h.Telemetry.Events.Should().BeEmpty();
+
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => h.Topology.Refreshed());
+        for (var i = 0; i < 8 && h.Factory.CreateCount == 1; i++)
+        {
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync(); // the remaining skipped intervals run out, then the refresh lands
+        }
+        await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+
+        h.Factory.CreateCount.Should().Be(2);
+        h.Telemetry.Events.Should().ContainInOrder("Redis.StaleEndpointDetected", "Redis.ForcedReconnect");
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_ResetsTheBackoff_AfterARefreshSucceeds()
+    {
+        var h = new Harness(retiredIsMember: true);
+        var fail = true;
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => fail ? throw new RedisTimeoutException(CommandFlags.None, "slow", CommandStatus.Unknown) : h.Topology.Refreshed());
+
+        await h.ScanTwiceAcrossThresholdAsync(); // fails once, skips two intervals
+        fail = false;
+        for (var i = 0; i < 3; i++)
+        {
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync();
+        }
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointStillAMember");
+
+        fail = true;
+        h.Clock.Advance(TimeSpan.FromMinutes(5));
+        await h.Connector.ScanStaleEndpointsAsync(); // no skip left over from the earlier failure
+        h.Telemetry.Exceptions.Should().HaveCount(2);
+        h.Clock.Advance(TimeSpan.FromSeconds(30));
+        await h.Connector.ScanStaleEndpointsAsync(); // skipped: the streak restarted at one failure
+        h.Telemetry.Exceptions.Should().HaveCount(2);
+        h.Connector.Dispose();
+    }
+
+    [Fact]
+    public async Task Scan_WaitsForAConnectedNode_BeforeJudgingTheConfiguration()
+    {
+        var h = new Harness(clusterConfigurationKnown: false);
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ =>
+        {
+            h.LiveServer.IsConnected.Returns(false); // the refresh itself dropped the last connection
+            return Task.FromResult(true);
+        });
+
+        await h.ScanTwiceAcrossThresholdAsync();
+
+        h.Telemetry.Events.Should().BeEmpty();
+        h.Telemetry.Exceptions.Should().BeEmpty();
+        h.Topology.Reads.Should().Be(0);
+
+        h.LiveServer.IsConnected.Returns(true);
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => h.Topology.Refreshed());
+        for (var refreshes = 0; refreshes < RedisConnector.NullTopologyRefreshLimit; refreshes++)
+        {
+            h.Clock.Advance(TimeSpan.FromSeconds(30));
+            await h.Connector.ScanStaleEndpointsAsync();
+        }
+
+        h.Factory.CreateCount.Should().Be(1);
+        h.Telemetry.Events.Should().Equal("Redis.StaleEndpointScanDisabled");
         h.Connector.Dispose();
     }
 
@@ -256,28 +529,13 @@ public class RedisConnectorStaleEndpointTests
     }
 
     [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("garbage")]
-    public async Task Scan_DoesNothing_WhenClusterNodesReplyIsUnusable(string? reply)
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Scan_DoesNotReconnectAgain_WhenMultiplexerWasSwappedDuringMembershipCheck(bool clusterConfigurationKnown)
     {
-        var h = new Harness();
-        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>()).Returns(Task.FromResult(reply));
-
-        await h.ScanTwiceAcrossThresholdAsync();
-
-        h.Factory.CreateCount.Should().Be(1);
-        h.Telemetry.Events.Should().BeEmpty();
-        h.Telemetry.Exceptions.Should().BeEmpty();
-        h.Connector.Dispose();
-    }
-
-    [Fact]
-    public async Task Scan_DoesNotReconnectAgain_WhenMultiplexerWasSwappedDuringMembershipCheck()
-    {
-        var h = new Harness();
-        var reply = new TaskCompletionSource<string?>(TaskCreationOptions.RunContinuationsAsynchronously);
-        h.LiveServer.ClusterNodesRawAsync(Arg.Any<CommandFlags>()).Returns(reply.Task);
+        var h = new Harness(clusterConfigurationKnown: clusterConfigurationKnown);
+        var refresh = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(refresh.Task);
         await h.Connector.ConnectAsync(TestContext.Current.CancellationToken);
         await h.Connector.ScanStaleEndpointsAsync();
         h.Clock.Advance(TimeSpan.FromMinutes(5));
@@ -285,7 +543,8 @@ public class RedisConnectorStaleEndpointTests
         var scan = h.Connector.ScanStaleEndpointsAsync();
         h.Connector.ForceReconnect();
         await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
-        reply.SetResult(ClusterNodesWithoutRetiredNodes);
+        await h.Topology.Refreshed();
+        refresh.SetResult(true);
         await scan;
 
         h.Factory.CreateCount.Should().Be(2);
@@ -328,33 +587,6 @@ public class RedisConnectorStaleEndpointTests
 
         h.Factory.CreateCount.Should().Be(0);
         h.Connector.Dispose();
-    }
-
-    [Fact]
-    public void ParseClusterNodeAddresses_ReadsIpAndHostname_SkipsNoAddr()
-    {
-        const string nodes =
-            "07c3 10.0.0.1:6379@16379,node-a.internal myself,master - 0 0 1 connected 0-5460\n" +
-            "a1b2 10.0.0.2:6379@16379 master - 0 1 2 connected 5461-10922\n" +
-            "c3d4 10.0.0.3:6379@16379,node-c.internal,shard-id=abc master - 0 1 3 connected 10923-16383\n" +
-            "e5f6 10.0.0.4:6379@16379,,shard-id=def master - 0 1 4 connected\n" +
-            "0789 2001:0db8:0:0:0:0:0:1:6379@16379 master - 0 1 5 connected\n" +
-            "dead :0@0 master,fail,noaddr - 0 0 0 disconnected\n" +
-            "\n";
-
-        var addresses = RedisConnector.ParseClusterNodeAddresses(nodes);
-
-        addresses.Should().BeEquivalentTo(["10.0.0.1:6379", "node-a.internal:6379", "10.0.0.2:6379", "10.0.0.3:6379", "node-c.internal:6379", "10.0.0.4:6379", "2001:db8::1:6379"]);
-        addresses.Should().Contain(RedisConnector.FormatEndPoint(new IPEndPoint(IPAddress.Parse("2001:db8::1"), 6379)));
-    }
-
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("garbage")]
-    public void ParseClusterNodeAddresses_IsEmpty_ForUnusableReplies(string? reply)
-    {
-        RedisConnector.ParseClusterNodeAddresses(reply).Should().BeEmpty();
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #153, from review feedback on the merged PR.

## The bug

The membership check called `IServer.ClusterNodesRawAsync()`. `CLUSTER` is an admin command in StackExchange.Redis, so with the default `allowAdmin=false` the client refuses it before it leaves the process with a `RedisCommandException`. That type derives from `Exception`, not `RedisServerException`, so the "not a cluster" filter never matched. The exception fell through to the outer catch, was tracked, and nothing reconnected. Every scan interval repeated it. The unit tests mocked `IServer`, so the client-side gate was never on the test path. Verified with a probe against a live server on 3.1.13: both `ClusterNodesRawAsync` and `ExecuteAsync("CLUSTER", "NODES")` are refused, since the string command maps back to `RedisCommand.CLUSTER`.

## The fix

- The scan calls `IConnectionMultiplexer.ConfigureAsync()`, which re-runs the handshake on every connected node. That handshake issues `CLUSTER NODES` as an internal call (`SetInternalCall`, written directly to the connection), so the admin gate does not apply. The scan then reads `IServer.ClusterConfiguration` from a connected node and compares node `EndPoint`s directly. The hand-written `CLUSTER NODES` parser goes away.
- When no connected node reports a cluster configuration (standalone server, or a Redis user without permission to run `CLUSTER NODES`), membership can never be judged. The scan emits one `Redis.StaleEndpointScanDisabled` event, disposes its timer, and stops for the lifetime of the connector. This addresses the second review point: a permanent permission problem no longer produces an unbounded telemetry stream.
- Transient refresh failures (timeouts, connection errors) are still tracked and the scan keeps running.
- If the refresh itself leaves no node connected, the scan does nothing and retries next interval rather than disabling itself.
- `ClusterConfiguration` has no public constructor, so the read of it sits behind a small internal `IClusterTopologyReader` seam that tests replace.

## Tests

- Unit tests rewritten around the new seam: reconnect on a departed node, node still a member, disable-once on missing configuration, timer stops after disabling, transient failure keeps scanning, no connected node after refresh waits, swapped multiplexer during refresh neither reconnects again nor disables.
- New integration test `RefreshClusterMembership_ReachesTheServer_UnderTheDefaultConnectionString` runs the real refresh against the CI Redis with the default connection string. It skips itself if the connection string sets `allowAdmin`. This is the test that would have caught the original bug.
- Full suite passes locally on net8.0 and net10.0. The integration tests were run against a local Redis as well.

## Docs

`resilience.md`, `settings.md` and the changelog describe the admin-free mechanism and the disable behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh
