### PR TITLE
test: stop the suite from starving its own thread pool

### DIFF
--- a/tests/UiPath.Caching.Tests/Broadcast/KeyedSubjectTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/KeyedSubjectTests.cs
@@ -287,7 +287,7 @@ public class KeyedSubjectTests
         var barrier = new Barrier(3);
 
         var ct = TestContext.Current.CancellationToken;
-        var subscribeTask = Task.Run(() =>
+        var subscribeTask = OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             var subs = new List<IDisposable>();
@@ -298,7 +298,7 @@ public class KeyedSubjectTests
             return subs;
         }, ct);
 
-        var dispatchTask = Task.Run(() =>
+        var dispatchTask = OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             for (var i = 0; i < iterations; i++)
@@ -307,7 +307,7 @@ public class KeyedSubjectTests
             }
         }, ct);
 
-        var unsubscribeTask = Task.Run(() =>
+        var unsubscribeTask = OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             for (var i = 0; i < iterations; i++)
@@ -341,7 +341,7 @@ public class KeyedSubjectTests
 
         var survivors = new ConcurrentBag<(TestKeyedObserver observer, IDisposable subscription)>();
 
-        var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(() =>
+        var tasks = Enumerable.Range(0, threadCount).Select(_ => OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             for (var i = 0; i < iterationsPerThread; i++)
@@ -353,7 +353,7 @@ public class KeyedSubjectTests
             var final_obs = new TestKeyedObserver(key);
             var final_sub = _sut.Subscribe(final_obs);
             survivors.Add((final_obs, final_sub));
-        })).ToArray();
+        }, CancellationToken.None)).ToArray();
 
         await Task.WhenAll(tasks);
 
@@ -424,7 +424,7 @@ public class KeyedSubjectTests
 
         var lateObservers = new ConcurrentBag<TestKeyedObserver>();
         var ct = TestContext.Current.CancellationToken;
-        var lateTask = Task.Run(() =>
+        var lateTask = OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             for (var i = 0; i < 50; i++)
@@ -435,7 +435,7 @@ public class KeyedSubjectTests
             }
         }, ct);
 
-        var dispatchTask = Task.Run(() =>
+        var dispatchTask = OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             for (var i = 0; i < eventCount; i++)
@@ -461,7 +461,7 @@ public class KeyedSubjectTests
         const int keyCount = 10;
         var barrier = new Barrier(threadCount);
 
-        var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+        var tasks = Enumerable.Range(0, threadCount).Select(t => OnDedicatedThread(() =>
         {
             barrier.SignalAndWait();
             for (var i = 0; i < opsPerThread; i++)
@@ -472,7 +472,7 @@ public class KeyedSubjectTests
                 _sut.OnNext(CreateEvent(key));
                 sub.Dispose();
             }
-        })).ToArray();
+        }, CancellationToken.None)).ToArray();
 
         await Task.WhenAll(tasks);
     }
@@ -523,6 +523,13 @@ public class KeyedSubjectTests
         public void OnError(Exception error) { }
         public void OnCompleted() => throw new InvalidOperationException("boom on completed");
     }
+
+    // Barrier participants on pool threads park the pool until it grows, starving every other test's timers and continuations.
+    private static Task OnDedicatedThread(Action action, CancellationToken token) =>
+        Task.Factory.StartNew(action, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+
+    private static Task<T> OnDedicatedThread<T>(Func<T> function, CancellationToken token) =>
+        Task.Factory.StartNew(function, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
 
     private sealed class ThrowingBroadcastObserver : IObserver<ICacheEvent>
     {

--- a/tests/UiPath.Caching.Tests/Config/DistributedCacheRegistrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Config/DistributedCacheRegistrationTests.cs
@@ -186,7 +186,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddRedis(_ => { });
                 b.AddDistributedCache(KnownCacheProviderNames.Redis, o => o.RedisKeyStrategyFactory = factory);
             },
@@ -210,7 +210,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddRedis(_ => { });
                 b.AddDistributedCache(KnownCacheProviderNames.Redis,
                     o => o.RedisKeyStrategyFactory = new ApplicationHashImpersonatingFactory());
@@ -249,7 +249,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddRedis(o => o.RedisKeyStrategyFactory = new FixedRedisKeyStrategyFactory());
                 b.AddDistributedCache(KnownCacheProviderNames.Redis);
             },
@@ -272,7 +272,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddRedis(_ => { });
                 b.AddDistributedCache(KnownCacheProviderNames.Redis,
                     o => o.RedisKeyStrategyFactory = new FixedRedisKeyStrategyFactory());
@@ -319,7 +319,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 if (distributedFirst)
                 {
                     b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
@@ -351,7 +351,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddInMemoryRedis(o => o.BroadcastEnable = providerBroadcast);
                 b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
             },
@@ -375,7 +375,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddDistributedCache(KnownCacheProviderNames.InMemoryRedis);
             },
             o => o.AppShortName = "app");
@@ -397,7 +397,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddRedis(_ => { });
                 b.AddDistributedCache(KnownCacheProviderNames.Redis);
             },
@@ -428,7 +428,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddRedis(o => o.AwaitRefresh = awaitRefresh);
             },
             o => o.AppShortName = "app");
@@ -553,7 +553,7 @@ public class DistributedCacheRegistrationTests
         services.AddCaching(
             b =>
             {
-                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
                 b.AddInMemoryRedis(o => o.CacheKeyStrategy = new LowercasingCacheKeyStrategy());
                 b.AddMemory(o => o.CacheKeyStrategy = new LowercasingCacheKeyStrategy());
                 b.AddDistributedCache(providerName);

--- a/tests/UiPath.Caching.Tests/Redis/RedisConnectorTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConnectorTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging.Abstractions;
+using StackExchange.Redis;
 using UiPath.Caching.Telemetry;
 
 namespace UiPath.Caching.Tests.Redis;
@@ -7,7 +8,6 @@ public class RedisConnectorTests : IAsyncLifetime
 {
     private readonly IFixture _fixture = AutoFixtureCreator.NSubstitute();
     private ICachingTelemetryProvider _telemetryProvider = default!;
-    private IRedisProfiler _profiler = default!;
     private IOptions<RedisConnectionOptions> _redisOptions = default!;
     private IRedisConfigurationOptionsProvider _redisConfigurationOptionsProvider = default!;
     private IConnectionMultiplexerFactory _connectionMultiplexerFactory = default!;
@@ -64,10 +64,15 @@ public class RedisConnectorTests : IAsyncLifetime
         return ValueTask.CompletedTask;
     }
 
+    private sealed class SubstituteMultiplexerFactory : IConnectionMultiplexerFactory
+    {
+        public ValueTask<IConnectionMultiplexer> CreateAsync(ConfigurationOptions configuration, CancellationToken cancellationToken = default) =>
+            new(Substitute.For<IConnectionMultiplexer>());
+    }
+
     public ValueTask InitializeAsync()
     {
         _telemetryProvider = _fixture.Create<ICachingTelemetryProvider>();
-        _profiler = _fixture.Create<IRedisProfiler>();
         _redisOptions = Options.Create(new RedisConnectionOptions
         {
             ConnectionString = _connectionString
@@ -75,7 +80,7 @@ public class RedisConnectorTests : IAsyncLifetime
         _fixture.Inject(_redisOptions);
         _redisConfigurationOptionsProvider = new RedisConfigurationOptionsProvider(NullLoggerFactory.Instance, _redisOptions);
         _fixture.Inject(_redisConfigurationOptionsProvider);
-        _connectionMultiplexerFactory = new ConnectionMultiplexerFactory(_redisOptions, _profiler);
+        _connectionMultiplexerFactory = new SubstituteMultiplexerFactory();
         _fixture.Inject(_connectionMultiplexerFactory);
         return ValueTask.CompletedTask;
     }


### PR DESCRIPTION
Full local runs had started failing on unrelated real-timer tests (`RehydrationCoordinatorTests`, `RedisCacheTests` FactoryTimeout, `RedisConnectorLifecycleTests.ForceReconnect_*`, the broadcast resubscribe and unknown-command tests), each overrunning its wait by 30 to 60 seconds. Per-test TRX timings showed the causes rather than the victims.

## Causes

- **Barrier tests on pool threads.** Three `KeyedSubjectTests` start 3, 20 and 50 `Task.Run` participants that all block on a `Barrier`. The pool has about one thread per core, so the 50-participant test alone pinned the whole pool for 16 to 28 seconds while the runtime injected threads; during that window no other test's timer callback or continuation could run. They now run on dedicated threads via `TaskCreationOptions.LongRunning`.
- **A real connection in a wiring test.** `RedisConnectorTests.NotNullConnection` used the real `ConnectionMultiplexerFactory` and blocked a pool thread for the full connect timeout through the synchronous `Database` property. It now uses a substitute factory; the assertion is about wiring, not connectivity.
- **Default timeouts against an unreachable Redis.** The `DistributedCacheRegistrationTests` connect to `localhost:6379`. Without a local Redis, each synchronous `Set`/`Get` waited the default 5-second sync timeout in the client's backlog before failing, so one test took 13 seconds of blocked pool thread. Their connection strings now set `connectTimeout=1000,syncTimeout=1000`. CI has a Redis on localhost, so nothing changes there.

## Effect

Eight consecutive full local runs after the change: all green, 21 to 30 seconds each. Before: 70 seconds to 3 minutes with one to four failures per run. The slowest test is now about 5 seconds, down from 28.

| | before | after |
|---|---|---|
| full run | 1m10s to 3m10s | 21s to 30s |
| slowest test | 27.8s | 5.2s |
| sum of ten slowest | 134s | 42s |

Test code only; no product change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh
