### PR TITLE
docs: release 2.0.0-preview.1 — CHANGELOG section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+## [2.0.0-preview.1] - 2026-09-08
+
+Preview of the 2.0 line. The public API surface below stays in `PublicAPI.Unshipped.txt` until
+2.0.0 ships, so it may still change between previews.
+
 ### Added
 
 - **`IDistributedCache` adapter.** `builder.AddDistributedCache(providerName)` registers a


### PR DESCRIPTION
Cuts the `Unreleased` changelog content into a `2.0.0-preview.1` section dated today and opens a fresh `Unreleased` above it.

Unlike the 1.2.0 and 1.3.0 release PRs, this one does **not** promote `PublicAPI.Unshipped.txt` into `PublicAPI.Shipped.txt`. Shipped means committed, and 2.0 still carries 60 pending removals against the 1.3.0 surface plus new API that may move between previews. Promotion happens in the 2.0.0 release PR.

After merge, tag `main` with `v2.0.0-preview.1`. The release workflow accepts `alpha`, `preview` and `rc` suffixes; it marks the GitHub release as a prerelease and the nuget.org push waits for manual approval in the `nuget` environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh
