### PR TITLE
test: suppress SER306 alongside SER305 in the test project

### DIFF
--- a/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
+++ b/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
@@ -7,8 +7,8 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
     <!-- AutoFixture.AutoNSubstitute 4.18.1 caps NSubstitute at <6, but 6.2.0 is used and passes; the pin is intentional. -->
     <NoWarn>$(NoWarn);NU1608</NoWarn>
-    <!-- SER305 flags awaiting a queued ITransaction command; here those awaits are NSubstitute Received() checks on a mock. -->
-    <NoWarn>$(NoWarn);SER305</NoWarn>
+    <!-- SER305/SER306 flag awaiting a queued or fire-and-forget command; here those awaits are NSubstitute Received() checks on a mock. -->
+    <NoWarn>$(NoWarn);SER305;SER306</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
StackExchange.Redis 3.1.31 ships analyzer SER306, which flags awaiting a `FireAndForget` command because its result is always the default value. The eight hits in the test project are all NSubstitute `Received()` verifications on a mocked `ITransaction`, the same false-positive shape SER305 had in #141, so the same suppression applies. The release build for 2.0.0-preview.1 was warning on them.

Test project only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh
