### PR TITLE
fix(cache): let packages reserve the Redis keyspaces the distributed cache must avoid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   distributed entry cannot be reached through the application's own `ICache`/`IHashCache` with the bare
   caller key, and `RedisKeyDifferentiator` plus `RedisKeyStrategyFactory` separate the physical Redis
   keyspace (`dh` by default, inheriting the application's factory). A differentiator matching one of the
-  application's own type prefixes is rejected at registration, and because a differentiator only
-  separates anything if the factory honors it, registration also proves the composed key differs from
-  what the application's caches would produce. Configurable via
+  application's own reserved keyspaces is rejected at registration, and because a differentiator only
+  separates anything if the factory honors it, resolving the cache also proves the composed key differs
+  from what the application's caches would produce. Configurable via
   `UiPathDistributedCacheOptions`: `PolicyName`, `DefaultEntryExpiration`, and
   `AllowUnboundedEntries`. Writes with no caller expiration take a bounded default rather than living
   forever in shared storage; an unset default resolves to `CachePolicy.DefaultDistributedExpiration`,
@@ -178,6 +178,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Changed
 
+- **BREAKING: `RedisTypePrefixes` is now `RedisKeyspaces`.** The library called the same thing two
+  names — the short segment between `AppShortName` and the cache key was a "type prefix" in the core
+  and a "keyspace" in the reservation API that packages register against. It is a keyspace
+  everywhere now: the class, the error messages, and the docs. Only the type rename is a break;
+  `IReservedRedisKeyspace` ships for the first time in this release, so its `Keyspace` member had no
+  earlier spelling to migrate from. The constant values are
+  untouched (`"s"`, `"h"`, `"ps"`, `"st"`), so no Redis key changes and no data moves; only the
+  identifiers do. Replace `RedisTypePrefixes` with `RedisKeyspaces` at the call site. "Prefix" now
+  means only what it says: `UiPathDistributedCacheOptions.CacheKeyStrategy`'s key prefix,
+  `PrefixStrategy`, and StackExchange's own `KeyPrefix`.
 - **BREAKING:** an unset expiration no longer means "keep this forever". `CachePolicy` gained
   `DefaultDistributedExpiration` (1 hour), applied as the floor under
   `CachePolicy.DistributedExpiration` and the providers' `DefaultExpiration` on every write that
@@ -375,6 +385,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   stops the loops, and the probe delegate must always run so its `finally` clears the in-progress
   flag. Test fakes moved off the obsolete `RedisServerException(string)` constructor.
 
+- **Reserved Redis keyspaces are extensible across packages (#130).** `AddDistributedCache` used to
+  compare `RedisKeyDifferentiator` against a hardcoded list of the core's Redis keyspaces, so a
+  package layered on top — `UiPath.Caching.Queue`'s set cache on `"se"` — was invisible to it and a
+  differentiator landing on those keys was accepted. Packages now declare the keyspaces they occupy
+  through `IServiceCollection.ReserveRedisKeyspace` (`IReservedRedisKeyspace`); the core reserves its
+  four and `AddQueueRedis` / `AddQueueInMemoryRedis` reserve `"se"`, whether or not that backing is
+  enabled. `AddDistributedCache` reserves its own differentiator the same way, so one registry answers
+  every case: the second party to claim a keyspace is rejected whichever it is, in either order, across
+  separate `AddCaching` calls, and even when `CacheOptions.Enabled` is false — a collision is a
+  configuration error rather than a runtime condition. Two packages claiming one keyspace is rejected
+  too, where before the later reservation was silently dropped; a repeat by the same owner is still
+  ignored. A keyspace, `RedisKeyDifferentiator` included, must be one segment of letters and digits, so
+  none can span segments under a punctuation separator; `CacheOptions.Separator` may itself be
+  alphanumeric, so one keyspace nesting inside another under the configured separator is rejected when the
+  options resolve. The resolution-time probe that guards a custom `IRedisKeyStrategyFactory` enumerates the
+  same reservations, skipping any the factory refuses to build a key for, and the default
+  differentiator is checked too in case a package reserves it.
 - **Stale endpoint detection works under the default `allowAdmin=false`.** The membership check
   issued `CLUSTER NODES`, which StackExchange.Redis refuses client-side unless admin mode is on, so on
   a default connection every scan recorded a `RedisCommandException` and never reconnected. The scan

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -57,10 +57,10 @@ there is no L1, cross-node invalidation via topics is also unnecessary for a
 `Redis`-only deployment, though the broadcast infrastructure remains available
 if you want it for other purposes.
 
-Every Redis key the lib writes carries a short *Redis type prefix* between
+Every Redis key the lib writes carries a short *Redis keyspace* segment between
 `AppShortName` and the logical key — `s` for `ICache` STRING values, `h` for
 `IHashCache` HASH values, `st` for Stream keys, `ps` for Pub/Sub channels (the
-constants live on `RedisTypePrefixes`). The prefix prevents type-collision
+constants live on `RedisKeyspaces`). The keyspace prevents type-collision
 errors when the same logical key is used by caches of different types: an
 `ICache<User>` write at `user:42` becomes `my-service:s:user:42` on Redis while
 an `IHashCache<UserField>` write at the same logical key becomes
@@ -584,7 +584,7 @@ rather than disabling the tier underneath it. Options bind from the same
 `Caching:InMemory` / `Caching:Redis` / `Caching:InMemoryRedis` sections as the core providers; see
 [reference/settings.md](reference/settings.md#queue-caches-uipathcachingqueue).
 
-On Redis the set cache keeps its own key namespace: the type-prefix slot holds `se`, where the
+On Redis the set cache keeps its own key namespace: the keyspace slot holds `se`, where the
 single-value cache holds `s` and the hash cache holds `h`, so a set and a string cache can share a
 key name without colliding. Writes are pinned to the master, reads prefer a replica, and an add is a
 transaction that applies `SADD` and the key's expiry together. Like the core Redis caches, a Redis

--- a/docs/how-to/broadcast.md
+++ b/docs/how-to/broadcast.md
@@ -258,7 +258,7 @@ Stream keys that contain `{`/`}` but do not form a valid non-empty hash tag (e.g
 
 ### Setting a custom search pattern
 
-For services that use a non-default stream key strategy, set `MaintainerSearchPattern` to scope the SCAN to only the keys your app owns. Without it the maintainer derives a pattern from `RedisStreamKeyStrategy` (defaulting to `PrefixStrategy` with `RedisTypePrefixes.Streams`), which covers the standard key layout but may pick up keys from other apps sharing the same Redis instance if the key prefix is not unique enough.
+For services that use a non-default stream key strategy, set `MaintainerSearchPattern` to scope the SCAN to only the keys your app owns. Without it the maintainer derives a pattern from `RedisStreamKeyStrategy` (defaulting to `PrefixStrategy` with `RedisKeyspaces.Streams`), which covers the standard key layout but may pick up keys from other apps sharing the same Redis instance if the key prefix is not unique enough.
 
 Example — a service using `PrefixStrategy` can derive the scan pattern at startup and stamp it onto the options before binding:
 
@@ -267,7 +267,7 @@ void Configure(ICachingBuilder builder) => builder
     .AddRedisStreams(opt =>
     {
         var cacheOptions = new CacheOptions { AppShortName = appShortName };
-        var keyFactory = new PrefixStrategy(RedisTypePrefixes.Streams, cacheOptions);
+        var keyFactory = new PrefixStrategy(RedisKeyspaces.Streams, cacheOptions);
         opt.MaintainerSearchPattern = keyFactory.GetRedisKey("*").ToString();
     });
 ```

--- a/docs/how-to/extending.md
+++ b/docs/how-to/extending.md
@@ -375,14 +375,39 @@ builder.AddDistributedCache(KnownCacheProviderNames.Redis, o =>
 ```
 
 Both default to values that keep the two keyspaces apart (`"d"` and `"dh"`); overriding them makes
-that separation yours to preserve. A differentiator matching one of the application's own
-`RedisTypePrefixes` is rejected at registration.
+that separation yours to preserve. A differentiator matching a keyspace any registered package has
+reserved is rejected at registration, whichever order the two were added in, whether or not they came
+from the same `AddCaching` call, and even when `CacheOptions.Enabled` is false, since a collision is a
+configuration error rather than a runtime condition: the core reserves its `RedisKeyspaces`, and
+`UiPath.Caching.Queue` reserves `"se"` for its set cache from both `AddQueueRedis` and
+`AddQueueInMemoryRedis`, including when the backing is disabled. A custom provider that occupies a
+keyspace of its own should declare it the same way, from its registration extension, so the check
+covers it wherever it was added:
+
+```csharp
+builder.Services.ReserveRedisKeyspace("li", "IListCache (My.Package)");
+```
+
+The keyspace is one segment of letters and digits, so no reservation can span segments under a
+punctuation separator. `CacheOptions.Separator` may itself be alphanumeric, which that rule cannot
+anticipate, so one keyspace nesting inside another under the configured separator is rejected when
+the options are resolved.
+The owner string names you in the error and is what a repeat reservation is matched on, so a package
+can reserve from several registration methods. Qualify it with the package name: two packages sharing
+one owner string on one keyspace read as one package reserving twice.
 
 For full control of the Redis key — a mandated layout, or a cluster hash-tag scheme —
 `RedisKeyStrategyFactory` replaces the factory the key is built from. It still receives
-`RedisKeyDifferentiator`, and registration proves the composed key differs from what the
-application's caches would produce, so a factory that ignores the differentiator fails at startup
-rather than sharing the keyspace:
+`RedisKeyDifferentiator`, and resolving the cache proves the composed key differs from what the
+application's caches and every reserved keyspace would produce, so a factory that lands on one fails
+instead of sharing the keyspace. That check runs when `IDistributedCache` is first resolved, which is
+at startup only if something resolves it then — otherwise on the first request that does. Resolve it
+during startup if you want the failure there.
+
+It is a probe, not a proof. Each reserved keyspace is rendered through the application's factory,
+which is exact for the caches and approximate for anything that composes its keys elsewhere, such as
+broadcast streams going through `RedisStreamKeyStrategy`. A custom factory that lands on one of those
+layouts without matching the probed one is not caught:
 
 ```csharp
 o.RedisKeyStrategyFactory = new MyRedisKeyStrategyFactory();   // gets "dh" (or your differentiator)

--- a/docs/how-to/telemetry-and-strategies.md
+++ b/docs/how-to/telemetry-and-strategies.md
@@ -176,25 +176,25 @@ When `RedisCacheOptions.KeyReadTelemetryEnabled` is set, read paths additionally
 Three segments are stitched together by the default `IRedisKeyStrategyFactory` before a key hits Redis:
 
 ```
-<AppShortName>:<RedisTypePrefix>:<your key after ICacheKeyStrategy>
+<AppShortName>:<RedisKeyspace>:<your key after ICacheKeyStrategy>
 ```
 
-`<RedisTypePrefix>` is a short literal from `UiPath.Caching.Redis.RedisTypePrefixes` that identifies the Redis data type the key holds:
+`<RedisKeyspace>` is a short literal from `UiPath.Caching.Redis.RedisKeyspaces` that identifies the Redis data type the key holds:
 
 | Constant | Value | Used for |
 |---|---|---|
-| `RedisTypePrefixes.String` | `s` | `ICache` / `ICache<T>` (Redis STRING via `SET`/`GET`) |
-| `RedisTypePrefixes.Hash` | `h` | `IHashCache` / `IHashCache<T>` (Redis HASH via `HSET`/`HGET`) |
-| `RedisTypePrefixes.Streams` | `st` | Redis Streams topic keys (`XADD` / `XREADGROUP`) |
-| `RedisTypePrefixes.PubSub` | `ps` | Pub/Sub channel names |
+| `RedisKeyspaces.String` | `s` | `ICache` / `ICache<T>` (Redis STRING via `SET`/`GET`) |
+| `RedisKeyspaces.Hash` | `h` | `IHashCache` / `IHashCache<T>` (Redis HASH via `HSET`/`HGET`) |
+| `RedisKeyspaces.Streams` | `st` | Redis Streams topic keys (`XADD` / `XREADGROUP`) |
+| `RedisKeyspaces.PubSub` | `ps` | Pub/Sub channel names |
 
 Worked example. With `AppShortName: "my-service"`, separator `:`, and an `ICacheFactory` extension that wraps `ICache<User>` in a `PrefixCacheKeyStrategy("user")`, the call `cache.SetAsync("42", user, ...)` produces the Redis key `my-service:s:user:42`. The corresponding `IHashCache<UserField>` extension produces `my-service:h:user:42`. **They cannot collide**: the same logical key in code resolves to a different Redis key per cache type, so an `ICache<T>` write (STRING) and an `IHashCache<T>` write (HASH) never produce a `WRONGTYPE` error against the same Redis key. Stream keys (`my-service:st:<topic>`) and Pub/Sub channels (`my-service:ps:<channel>`) live in their own segments for the same reason.
 
-The type prefix is inserted by `DefaultRedisKeyStrategyFactory` based on whether the registered cache implements `ICache` or `IHashCache`. Overriding `RedisCacheOptions.RedisKeyStrategyFactory` lets you replace this behavior wholesale, but the default is the right call for almost every consumer — opt out only when you have a legacy Redis layout you must match.
+The keyspace segment is inserted by `DefaultRedisKeyStrategyFactory` based on whether the registered cache implements `ICache` or `IHashCache`. Overriding `RedisCacheOptions.RedisKeyStrategyFactory` lets you replace this behavior wholesale, but the default is the right call for almost every consumer — opt out only when you have a legacy Redis layout you must match.
 
 ### The `ICacheKeyStrategy` seam
 
-`ICacheKeyStrategy` rewrites the *logical* key (the third segment above) before the Redis key factory adds the type-prefix and app-prefix segments. Two built-ins are provided:
+`ICacheKeyStrategy` rewrites the *logical* key (the third segment above) before the Redis key factory adds the keyspace and app-prefix segments. Two built-ins are provided:
 
 - `DefaultCacheKeyStrategy` — pass-through; the key reaches the store unmodified (apart from any `AppShortName` / `KeyPrefix` prepended by the provider).
 - `PrefixCacheKeyStrategy(prefix, separator)` — prepends `prefix + separator` to every key. Used as the default for typed caches constructed via `Cache<T>(provider, strategy)`.
@@ -243,7 +243,7 @@ Four code-only seams shape how the library names things on Redis. None bind from
 
 | Seam | Interface | Purpose | Set on |
 |---|---|---|---|
-| Redis key factory | `IRedisKeyStrategyFactory` | Builds the function combining `AppShortName + differentiator + cache key` into the final Redis key string. Default handles `ICache` (string type prefix) and `IHashCache` (hash type prefix), with optional shard-key support. | `RedisCacheOptions.RedisKeyStrategyFactory` |
+| Redis key factory | `IRedisKeyStrategyFactory` | Builds the function combining `AppShortName + differentiator + cache key` into the final Redis key string. Default handles `ICache` (the string keyspace) and `IHashCache` (the hash keyspace), with optional shard-key support. | `RedisCacheOptions.RedisKeyStrategyFactory` |
 | Streams key | `IRedisStreamKeyStrategy` | Builds the Redis key for a Streams topic (the key of the stream itself). | `RedisStreamsTopicOptions.RedisStreamKeyStrategy` |
 | Pub/Sub channel | `IRedisChannelStrategy` | Builds the channel name for a Pub/Sub topic or the streams notify doorbell. | `RedisPubSubTopicOptions.RedisChannelStrategy` / `RedisStreamsTopicOptions.NotifyChannelStrategy` |
 | Distributed lock key | `IDistributedLockKeyStrategy` | Builds the lock key for `RedisDistributedLock`. Default appends `":lck"` (separator + `"lck"`) to `CacheKey.Name`. | `IMultilayerCacheOptions.LockKeyStrategy` |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -32,7 +32,7 @@ Alphabetical lookup for terms used across the docs.
 
 **Per-topic overlay** — The `Topics[]` array under `Broadcast:RedisStreams` / `Broadcast:RedisPubSub`. Each entry's fields override the app-wide values for that topic only. See [how-to/broadcast.md](../how-to/broadcast.md#per-topic-overrides).
 
-**Redis type prefix** — A short literal segment (`s`, `h`, `st`, `ps`) inserted between `AppShortName` and the cache key by `DefaultRedisKeyStrategyFactory`. Identifies the Redis data type the key holds (STRING / HASH / Stream / Pub-Sub channel) so caches of different types cannot collide on the same Redis key. Constants live on `UiPath.Caching.Redis.RedisTypePrefixes`. See [how-to/telemetry-and-strategies.md](../how-to/telemetry-and-strategies.md#final-key-shape-on-redis).
+**Redis keyspace** — A short literal segment inserted between `AppShortName` and the rest of the key. `DefaultRedisKeyStrategyFactory` inserts `s` and `h` for the caches; the broadcast paths insert `st` and `ps` through their own `PrefixStrategy`. Packages layered on the library reserve their own through `ReserveRedisKeyspace`. Identifies the Redis data type the key holds (STRING / HASH / Stream / Pub-Sub channel) so caches of different types cannot collide on the same Redis key. Constants live on `UiPath.Caching.Redis.RedisKeyspaces`. See [how-to/telemetry-and-strategies.md](../how-to/telemetry-and-strategies.md#final-key-shape-on-redis).
 
 **Separator** — `CacheOptions.Separator`, default `:`. Joins prefix segments in keys, channel names, and stream keys.
 

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -271,7 +271,7 @@ extension rather than bound from configuration.
 | Property | Type | Default | Scope | Notes |
 |---|---|---|---|---|
 | `CacheKeyStrategy` | `ICacheKeyStrategy?` | `null` | Per registration | Composes the stored key from the caller key. Null applies `PrefixCacheKeyStrategy` with `DefaultKeyPrefix` (`"d"`); pass `new PrefixCacheKeyStrategy("d:sess")` to sub-namespace while keeping that prefix, or `DefaultCacheKeyStrategy` to opt out of prefixing entirely. Code-only seam. |
-| `RedisKeyDifferentiator` | `string?` | `null` | Per registration | Fills the slot after `AppShortName` that the application's caches fill with a `RedisTypePrefixes` value. Null uses `DefaultRedisKeyDifferentiator` (`"dh"`). Inert on the `InMemory` tier; a value matching a `RedisTypePrefixes` value is rejected at registration. Prefixes belonging to packages layered on top of `UiPath.Caching` are **not** checked — it cannot see them without depending on them — so avoid those too: `UiPath.Caching.Queue`'s set cache uses `"se"`. |
+| `RedisKeyDifferentiator` | `string?` | `null` | Per registration | Fills the slot after `AppShortName` that the application's caches fill with a `RedisKeyspaces` value. Null uses `DefaultRedisKeyDifferentiator` (`"dh"`). Inert on the `InMemory` tier. A value matching a keyspace any registered package reserved is rejected at registration, in whichever order the two were registered, from separate `AddCaching` calls, and even with `Enabled` false: the core's `RedisKeyspaces`, and `"se"` once `AddQueueRedis` / `AddQueueInMemoryRedis` is on the builder, enabled or not. Packages declare theirs with `IServiceCollection.ReserveRedisKeyspace`. |
 | `RedisKeyStrategyFactory` | `IRedisKeyStrategyFactory?` | `null` | Per registration | Builds the Redis key, receiving `RedisKeyDifferentiator`. Null inherits the application's `RedisCacheOptions.RedisKeyStrategyFactory`, keeping its `AppShortName`, separator and sharding conventions. Code-only seam. |
 | `PolicyName` | `string?` | `null` | Per registration | Named `CachePolicy` applied to the adapter's operations; an unregistered name fails fast at startup. |
 | `DefaultEntryExpiration` | `TimeSpan?` | `null` | Per registration | Expiration used when the caller supplies none. `IDistributedCache` treats absent expiration as "until removed"; unless `AllowUnboundedEntries` is set that is mapped to this value, falling back to the backing tier's `DefaultExpiration` and then to `CachePolicy.DefaultDistributedExpiration`. |
@@ -318,10 +318,16 @@ prefixes the `CacheKey` itself, so a distributed entry cannot be reached through
 `ICache`/`IHashCache` with the bare caller key, and the memory tiers' local lock keyspace (keyed by
 provider name plus cache key) stays separate too — neither of which a Redis-key-level segment can do.
 `RedisKeyDifferentiator` and `RedisKeyStrategyFactory` separate the physical Redis keyspace, taking the
-slot the application's caches fill with a `RedisTypePrefixes` value. Because a differentiator only separates anything if the factory
-honors it, registration composes a probe key both ways and fails when the distributed key matches what
-the application's own caches would produce — so a factory that ignores its differentiator argument is
-rejected instead of quietly sharing the keyspace.
+slot the application's caches fill with a `RedisKeyspaces` value. A differentiator landing on a
+keyspace some package reserved — the core's own, or `"se"` from `UiPath.Caching.Queue` — is rejected at
+registration, in whichever order the two were registered and even from separate `AddCaching` calls.
+Because a differentiator only separates anything if the factory honors it, a second check composes a
+probe key both ways and fails when the distributed key matches what the application's caches or any
+reserved keyspace would produce, so a factory landing on one is rejected instead of quietly sharing
+the keyspace. That one runs when the Redis-backed cache is resolved, which is startup only if
+something resolves `IDistributedCache` there. It renders each reserved keyspace through the
+application's factory, so it is exact for the caches and approximate for keyspaces whose owner
+composes keys elsewhere, such as broadcast streams.
 
 The cache-key strategy is applied by the adapter rather than by the backing provider's own
 `ICacheOptions.CacheKeyStrategy`, which `RedisHashCache` does not consult — routing it through the

--- a/src/UiPath.Caching.Queue/Config/QueueCacheCollectionExtensions.cs
+++ b/src/UiPath.Caching.Queue/Config/QueueCacheCollectionExtensions.cs
@@ -14,6 +14,8 @@ namespace UiPath.Caching.Queue.Config;
 [ExcludeFromCodeCoverage]
 public static class QueueCacheCollectionExtensions
 {
+    private const string SetCacheKeyspaceOwner = "ISetCache (UiPath.Caching.Queue)";
+
     public static ICachingBuilder AddQueueMemory(this ICachingBuilder builder) =>
         builder.AddQueueMemory(KnownCacheProviderNames.InMemory);
 
@@ -70,6 +72,7 @@ public static class QueueCacheCollectionExtensions
         var options = new RedisSetCacheOptions();
         configureOptions.Invoke(options);
         builder.Services.TryConfigure(configureOptions);
+        builder.Services.ReserveRedisKeyspace(RedisSetCache.RedisSetKeyspace, SetCacheKeyspaceOwner);
         if (!builder.Enabled || !options.Enabled)
         {
             builder.Services.AddNullQueueCache();
@@ -102,6 +105,7 @@ public static class QueueCacheCollectionExtensions
         var options = new InMemoryRedisQueueCacheOptions();
         configureOptions.Invoke(options);
         builder.Services.TryConfigure(configureOptions);
+        builder.Services.ReserveRedisKeyspace(RedisSetCache.RedisSetKeyspace, SetCacheKeyspaceOwner);
         if (!builder.Enabled || !options.Enabled)
         {
             builder.Services.AddNullQueueCache();
@@ -118,7 +122,7 @@ public static class QueueCacheCollectionExtensions
         return builder;
     }
     
-    private static IServiceCollection AddQueueCacheCore(this IServiceCollection services)
+    private static void AddQueueCacheCore(this IServiceCollection services)
     {
         services.TryAddSingleton<IQueueCacheFactory>(sp =>
             new QueueCacheFactory(sp.GetRequiredService<IOptions<CacheOptions>>(), sp.GetServices<IQueueCacheProvider>()));
@@ -127,14 +131,12 @@ public static class QueueCacheCollectionExtensions
         services.TryAddTransient<Func<IQueueCacheFactory>>(sp => () => sp.GetRequiredService<IQueueCacheFactory>());
         services.TryAddSingleton<ISetCache>(sp => sp.GetRequiredService<IQueueCacheFactory>().CreateSetCache());
         services.TryAddTransient(typeof(ISetCache<>), typeof(SetCache<>));
-        return services;
     }
 
-    private static IServiceCollection AddNullQueueCache(this IServiceCollection services)
+    private static void AddNullQueueCache(this IServiceCollection services)
     {
         services.TryAddSingleton<ISetCache>(NullSetCache.Instance);
         services.TryAddSingleton<IQueueCacheFactory>(NullQueueCacheFactory.Instance);
         services.TryAddTransient(typeof(ISetCache<>), typeof(SetCache<>));
-        return services;
     }
 }

--- a/src/UiPath.Caching.Queue/RedisSetCache.cs
+++ b/src/UiPath.Caching.Queue/RedisSetCache.cs
@@ -5,7 +5,7 @@ namespace UiPath.Caching.Redis;
 
 public sealed partial class RedisSetCache : RedisCacheBase, ISetCache
 {
-    private const string RedisSetKeyPrefix = "se";
+    internal const string RedisSetKeyspace = "se";
 
     private readonly ILogger<RedisSetCache> _logger;
     private readonly ISerializerProxy<byte[]> _serializer;
@@ -34,7 +34,7 @@ public sealed partial class RedisSetCache : RedisCacheBase, ISetCache
         _write = resiliencePipelineProvider.Get(ResiliencePipelineNames.Write);
         _pop = resiliencePipelineProvider.Get(setCacheOptions.ResilienceKeyName);
         _cacheOptions = cacheOptions;
-        _redisKeyStrategy = (redisCacheOptions.RedisKeyStrategyFactory ?? new DefaultRedisKeyStrategyFactory()).Create(_cacheOptions, RedisSetKeyPrefix);
+        _redisKeyStrategy = (redisCacheOptions.RedisKeyStrategyFactory ?? new DefaultRedisKeyStrategyFactory()).Create(_cacheOptions, RedisSetKeyspace);
     }
 
     public string Name => KnownCacheProviderNames.Redis;

--- a/src/UiPath.Caching/Broadcast/Redis/RedisPubSubTopicProvider.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisPubSubTopicProvider.cs
@@ -34,7 +34,7 @@ public class RedisPubSubTopicProvider : RedisTopicProviderBase
         _resiliencePipelineProvider = resiliencePipelineProvider;
         _logger = loggerFactory.Create<RedisPubSubTopicProvider>();
         _sourceUri = cacheOptions.SourceUri ?? CacheOptions.MachineUri;
-        _defaultChannelStrategy = _options.RedisChannelStrategy ?? new PrefixStrategy(RedisTypePrefixes.PubSub, cacheOptions);
+        _defaultChannelStrategy = _options.RedisChannelStrategy ?? new PrefixStrategy(RedisKeyspaces.PubSub, cacheOptions);
         Enabled = _options.Enabled;
     }
 

--- a/src/UiPath.Caching/Broadcast/Redis/RedisStreamHealthMaintainer.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisStreamHealthMaintainer.cs
@@ -84,11 +84,11 @@ public partial class RedisStreamHealthMaintainer : IHostedService
     {
         _timer = new PeriodicTimer(_streamOptions.MaintainerCheckInterval);
         var keyFactory = _redisOptions.RedisKeyStrategyFactory ?? new DefaultRedisKeyStrategyFactory();
-        var stringKeyStrategy = keyFactory.Create(_cacheOptions, RedisTypePrefixes.String);
-        var hashKeyStrategy = keyFactory.Create(_cacheOptions, RedisTypePrefixes.Hash);
+        var stringKeyStrategy = keyFactory.Create(_cacheOptions, RedisKeyspaces.String);
+        var hashKeyStrategy = keyFactory.Create(_cacheOptions, RedisKeyspaces.Hash);
         if (string.IsNullOrWhiteSpace(_streamOptions.MaintainerSearchPattern))
         {
-            var redisStreamKeyStrategy = _streamOptions.RedisStreamKeyStrategy ?? new PrefixStrategy(RedisTypePrefixes.Streams, _cacheOptions);
+            var redisStreamKeyStrategy = _streamOptions.RedisStreamKeyStrategy ?? new PrefixStrategy(RedisKeyspaces.Streams, _cacheOptions);
             _streamsSearchPattern = redisStreamKeyStrategy.GetRedisKey("*").ToString();
         }
         else

--- a/src/UiPath.Caching/Broadcast/Redis/RedisStreamsTopic.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisStreamsTopic.cs
@@ -58,7 +58,7 @@ public sealed partial class RedisStreamsTopic<T> : ITopic<T>
         _cachingTelemetryProvider = cachingTelemetryProvider;
         _streamOptions = streamOptions;
         _subject = subjectFactory();
-        _redisStreamKeyStrategy = streamOptions.RedisStreamKeyStrategy ?? new PrefixStrategy(RedisTypePrefixes.Streams, cacheOptions);
+        _redisStreamKeyStrategy = streamOptions.RedisStreamKeyStrategy ?? new PrefixStrategy(RedisKeyspaces.Streams, cacheOptions);
         if (_streamOptions.NotifyEnabled)
         {
             var notifyChannelStrategy = streamOptions.NotifyChannelStrategy

--- a/src/UiPath.Caching/Config/CachingBuilder.cs
+++ b/src/UiPath.Caching/Config/CachingBuilder.cs
@@ -19,6 +19,10 @@ public class CachingBuilder(IServiceCollection services, IConfiguration? configu
 
     internal void Complete()
     {
+        // Before the switch: a keyspace collision is a configuration error, not a runtime condition.
+        Services.TryAddEnumerable(
+            ServiceDescriptor.Singleton<IValidateOptions<CacheOptions>, ReservedRedisKeyspaceValidator>());
+
         if(!Enabled)
         {
             return;

--- a/src/UiPath.Caching/Config/DistributedCacheCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/DistributedCacheCollectionExtensions.cs
@@ -12,20 +12,6 @@ public static class DistributedCacheCollectionExtensions
     /// <summary>Service key of the distributed cache's private <see cref="ICacheProvider"/> and <see cref="IHashCache"/> registrations.</summary>
     public const string DistributedCacheServiceKey = "UiPath.Caching.Distributed";
 
-    /// <summary>
-    /// The application's own caches fill the differentiator slot with a <see cref="RedisTypePrefixes"/>
-    /// value, so a distributed differentiator matching one of them would merge the two keyspaces. Only this
-    /// assembly's prefixes are listed: a package layered on top of it defines its own, which this assembly
-    /// cannot see without depending on it the wrong way round.
-    /// </summary>
-    private static readonly string[] ApplicationTypePrefixes =
-    [
-        RedisTypePrefixes.String,
-        RedisTypePrefixes.Hash,
-        RedisTypePrefixes.PubSub,
-        RedisTypePrefixes.Streams,
-    ];
-
     /// <summary>Registers an <see cref="IDistributedCache"/> backed by a dedicated case-sensitive cache instance in its own keyspace. <paramref name="providerName"/> selects the backing tier: Redis (recommended), InMemoryRedis, or InMemory.</summary>
     public static ICachingBuilder AddDistributedCache(
         this ICachingBuilder builder,
@@ -35,21 +21,27 @@ public static class DistributedCacheCollectionExtensions
         Guard.NotNullOrWhiteSpace(providerName, nameof(providerName));
         var options = new UiPathDistributedCacheOptions();
         configure?.Invoke(options);
-        EnsureKeyspaceIsolation(options);
+        EnsureDifferentiatorIsNotBlank(options);
 
-        if (builder.Services.Any(d => d.IsKeyedService
-            && Equals(d.ServiceKey, DistributedCacheServiceKey)
-            && d.ServiceType == typeof(IHashCache)))
+        // Read from the reservation rather than from the registered adapter: a disabled call registers no
+        // adapter, and the two paths have to agree on what "already called" means.
+        if (builder.Services.HasDistributedCacheRedisKeyspace())
         {
             throw new InvalidOperationException(
                 "AddDistributedCache has already been called. Registering it twice would build the adapter from the first call's options over the second call's backing tier; call it once.");
         }
+
+        // The differentiator occupies a keyspace like any package's, so reserving it is the whole check:
+        // it fails on a keyspace already taken, and makes a later package's reservation fail. Done before
+        // the Enabled short-circuit, because a collision is a configuration error either way.
+        builder.Services.ReserveDistributedCacheRedisKeyspace(ResolveRedisKeyDifferentiator(options));
 
         if (!builder.Enabled)
         {
             RegisterNullAdapter(builder);
             return builder;
         }
+
 
         if (providerName is KnownCacheProviderNames.InMemory or KnownCacheProviderNames.InMemoryRedis)
         {
@@ -151,28 +143,12 @@ public static class DistributedCacheCollectionExtensions
     private static string ResolveRedisKeyDifferentiator(UiPathDistributedCacheOptions options) =>
         options.RedisKeyDifferentiator ?? UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator;
 
-    /// <summary>
-    /// Both keyspace seams are overridable, so reject values that would merge them back into the application's.
-    /// The prefix comparison ignores case because <see cref="PrefixRedisKeyStrategy"/> lowercases what it is
-    /// given: <c>"H"</c> composes the application's <c>"h"</c> keyspace, which an ordinal match would wave through.
-    /// </summary>
-    private static void EnsureKeyspaceIsolation(UiPathDistributedCacheOptions options)
+    private static void EnsureDifferentiatorIsNotBlank(UiPathDistributedCacheOptions options)
     {
-        if (options.RedisKeyDifferentiator is not { } differentiator)
-        {
-            return;
-        }
-
-        if (string.IsNullOrWhiteSpace(differentiator))
+        if (options.RedisKeyDifferentiator is { } differentiator && string.IsNullOrWhiteSpace(differentiator))
         {
             throw new InvalidOperationException(
                 "UiPathDistributedCacheOptions.RedisKeyDifferentiator must be a non-empty value, or null to use the default.");
-        }
-
-        if (ApplicationTypePrefixes.Contains(differentiator, StringComparer.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException(
-                $"UiPathDistributedCacheOptions.RedisKeyDifferentiator '{differentiator}' is one of the type prefixes the application's own caches use, which would put the distributed cache in the same Redis keyspace. Choose another value.");
         }
     }
 
@@ -308,7 +284,8 @@ public static class DistributedCacheCollectionExtensions
                 sp.GetRequiredService<IOptions<RedisCacheOptions>>().Value,
                 options,
                 cacheOptions.Value,
-                differentiator)),
+                differentiator,
+                sp.GetServices<IReservedRedisKeyspace>().ValidatedFor(cacheOptions.Value.Separator))),
             cacheOptions,
             connector,
             new RawByteSerializerProxy(sp.GetService<JsonSerializerOptions>()),
@@ -327,12 +304,13 @@ public static class DistributedCacheCollectionExtensions
         RedisCacheOptions source,
         UiPathDistributedCacheOptions options,
         CacheOptions cacheOptions,
-        string differentiator)
+        string differentiator,
+        IEnumerable<IReservedRedisKeyspace> reserved)
     {
         var applicationFactory = source.RedisKeyStrategyFactory ?? new DefaultRedisKeyStrategyFactory();
         var distributedFactory = options.RedisKeyStrategyFactory ?? applicationFactory;
         EnsureDifferentiatedKeyspace(
-            distributedFactory, applicationFactory, cacheOptions, differentiator, ResolveCacheKeyStrategy(options));
+            distributedFactory, applicationFactory, cacheOptions, differentiator, ResolveCacheKeyStrategy(options), reserved);
 
         var copy = source.ShallowCopy();
         copy.RedisKeyStrategyFactory = new DistributedRedisKeyStrategyFactory(distributedFactory, differentiator);
@@ -380,17 +358,18 @@ public static class DistributedCacheCollectionExtensions
         IRedisKeyStrategyFactory applicationFactory,
         CacheOptions cacheOptions,
         string differentiator,
-        ICacheKeyStrategy keyStrategy)
+        ICacheKeyStrategy keyStrategy,
+        IEnumerable<IReservedRedisKeyspace> reserved)
     {
         var probe = keyStrategy.GetCacheKey<byte[]>(new CacheKey("probe", CacheKeyCasing.Sensitive));
         var distributed = distributedFactory.Create(cacheOptions, differentiator).GetRedisKey(probe);
 
-        foreach (var (description, applicationKey) in ApplicationProbes(applicationFactory, cacheOptions, probe))
+        foreach (var (description, applicationKey) in ApplicationProbes(applicationFactory, cacheOptions, probe, reserved))
         {
             if (applicationKey == distributed)
             {
                 throw new InvalidOperationException(
-                    $"The Redis key strategy maps distributed entries onto the same key as the application's {description} caches, so the two would share one keyspace. Either the differentiator '{differentiator}' is not distinct, or the configured IRedisKeyStrategyFactory ignores the differentiator it is given.");
+                    $"The Redis key strategy maps distributed entries onto the same key as {description}, so the two would share one keyspace. Either the differentiator '{differentiator}' is not distinct, or the configured IRedisKeyStrategyFactory ignores the differentiator it is given.");
             }
         }
     }
@@ -399,18 +378,62 @@ public static class DistributedCacheCollectionExtensions
     /// The keys the application's own Redis caches would produce. <c>RedisCache</c> and <c>RedisHashCache</c>
     /// resolve their strategy through the <see cref="Type"/> overload, so the probe has to use it too: a custom
     /// factory may implement the two overloads differently, and comparing only the string one would let a
-    /// colliding layout through. The string overload is still probed, for a factory that only implements that.
+    /// colliding layout through. The string overload is probed for every reserved keyspace, for a factory that
+    /// only implements that and for the packages layered on top, whose cache types this assembly cannot name.
+    /// <para>Every reserved keyspace is rendered through the application's factory, which is exact for caches
+    /// and approximate for anything that composes its keys elsewhere — broadcast streams, for one, go through
+    /// <c>RedisStreamKeyStrategy</c>. Catching those exactly would mean each reservation carrying its own
+    /// renderer.</para>
     /// </summary>
     private static IEnumerable<(string Description, RedisKey Key)> ApplicationProbes(
-        IRedisKeyStrategyFactory inner, CacheOptions cacheOptions, CacheKey probe)
+        IRedisKeyStrategyFactory inner, CacheOptions cacheOptions, CacheKey probe, IEnumerable<IReservedRedisKeyspace> reserved)
     {
-        yield return ($"'{RedisTypePrefixes.String}' (ICache)", inner.Create(cacheOptions, typeof(RedisCache)).GetRedisKey(probe));
-        yield return ($"'{RedisTypePrefixes.Hash}' (IHashCache)", inner.Create(cacheOptions, typeof(RedisHashCache)).GetRedisKey(probe));
-
-        foreach (var applicationPrefix in ApplicationTypePrefixes)
+        var seen = new HashSet<RedisKey>();
+        var cacheKey = inner.Create(cacheOptions, typeof(RedisCache)).GetRedisKey(probe);
+        if (seen.Add(cacheKey))
         {
-            yield return ($"'{applicationPrefix}'", inner.Create(cacheOptions, applicationPrefix).GetRedisKey(probe));
+            yield return ($"'{RedisKeyspaces.String}' (ICache)", cacheKey);
         }
+
+        var hashKey = inner.Create(cacheOptions, typeof(RedisHashCache)).GetRedisKey(probe);
+        if (seen.Add(hashKey))
+        {
+            yield return ($"'{RedisKeyspaces.Hash}' (IHashCache)", hashKey);
+        }
+
+        foreach (var keyspace in reserved)
+        {
+            // Its own reservation is the key under test, and a factory that refuses to build a key for
+            // someone else's keyspace cannot land on it either.
+            if (keyspace.IsDistributedCache() || !TryProbe(inner, cacheOptions, probe, keyspace.Keyspace, out var key))
+            {
+                continue;
+            }
+
+            if (seen.Add(key))
+            {
+                yield return ($"'{keyspace.Keyspace}' ({keyspace.Owner})", key);
+            }
+        }
+    }
+
+    /// <summary>Only a refused keyspace is skipped: a strategy that builds but then fails on the probe key is a real fault, so it surfaces.</summary>
+    private static bool TryProbe(
+        IRedisKeyStrategyFactory inner, CacheOptions cacheOptions, CacheKey probe, string keyspace, out RedisKey key)
+    {
+        IRedisKeyStrategy strategy;
+        try
+        {
+            strategy = inner.Create(cacheOptions, keyspace);
+        }
+        catch (Exception)
+        {
+            key = default;
+            return false;
+        }
+
+        key = strategy.GetRedisKey(probe);
+        return true;
     }
 
     /// <summary>

--- a/src/UiPath.Caching/Config/ServiceCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/ServiceCollectionExtensions.cs
@@ -61,6 +61,10 @@ public static class ServiceCollectionExtensions
         services.TryAddTransient(typeof(IHashCache<>), typeof(HashCache<>));
 
         services.TryAddTimeProvider();
+        services.ReserveRedisKeyspace(RedisKeyspaces.String, "ICache");
+        services.ReserveRedisKeyspace(RedisKeyspaces.Hash, "IHashCache");
+        services.ReserveRedisKeyspace(RedisKeyspaces.PubSub, "broadcast pub/sub channels");
+        services.ReserveRedisKeyspace(RedisKeyspaces.Streams, "broadcast streams");
         var builder = new CachingBuilder(services, configuration)
         {
             Enabled = options.Enabled

--- a/src/UiPath.Caching/Distributed/UiPathDistributedCacheOptions.cs
+++ b/src/UiPath.Caching/Distributed/UiPathDistributedCacheOptions.cs
@@ -19,10 +19,10 @@ public class UiPathDistributedCacheOptions
     public ICacheKeyStrategy? CacheKeyStrategy { get; set; }
 
     /// <summary>
-    /// Differentiator handed to the Redis key strategy, placed after <c>AppShortName</c>, in the slot the
-    /// application's own caches fill with a <see cref="RedisTypePrefixes"/> value. Null uses <c>"dh"</c>.
-    /// Inert on the InMemory tier, and a value matching one of the application's type prefixes is rejected
-    /// at registration.
+    /// Value placed after <c>AppShortName</c>, in the slot the application's caches fill with a
+    /// <see cref="RedisKeyspaces"/> value. Null uses <c>"dh"</c>; inert on the InMemory tier. One segment of
+    /// letters and digits, like every reserved keyspace. A value any package reserved is rejected at
+    /// registration, in either order and even when caching is disabled.
     /// </summary>
     public string? RedisKeyDifferentiator { get; set; }
 
@@ -30,10 +30,12 @@ public class UiPathDistributedCacheOptions
     /// Builds the Redis key from the composed <see cref="CacheKey"/>, receiving
     /// <see cref="RedisKeyDifferentiator"/>. Null uses the one the application configured on
     /// <see cref="RedisCacheOptions.RedisKeyStrategyFactory"/>, so the distributed cache inherits its
-    /// <c>AppShortName</c>, separator and sharding conventions. Set this to take over the layout entirely —
-    /// for a mandated key shape, or a cluster hash-tag scheme. Registration proves the resulting keys differ
-    /// from the application's, so a factory that ignores the differentiator is rejected rather than silently
-    /// sharing the keyspace.
+    /// <c>AppShortName</c>, separator and sharding conventions. Set this to take over the layout entirely.
+    /// A layout that lands on the application's own keys, or on a reserved keyspace, is rejected when
+    /// <c>IDistributedCache</c> is first resolved, which is startup only if something resolves it there.
+    /// Ignoring the differentiator is fine as long as the keys stay disjoint. The check is a probe rather
+    /// than a proof: reserved keyspaces are rendered through the application's factory, so a keyspace whose
+    /// owner composes keys elsewhere, as broadcast streams do, is only approximated.
     /// </summary>
     public IRedisKeyStrategyFactory? RedisKeyStrategyFactory { get; set; }
 

--- a/src/UiPath.Caching/PublicAPI.Unshipped.txt
+++ b/src/UiPath.Caching/PublicAPI.Unshipped.txt
@@ -101,3 +101,18 @@ UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointThreshold.get -> System
 UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointThreshold.set -> void
 UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointScanInterval.get -> System.TimeSpan
 UiPath.Caching.Redis.RedisConnectionOptions.StaleEndpointScanInterval.set -> void
+UiPath.Caching.Redis.IReservedRedisKeyspace
+UiPath.Caching.Redis.IReservedRedisKeyspace.Owner.get -> string!
+UiPath.Caching.Redis.IReservedRedisKeyspace.Keyspace.get -> string!
+UiPath.Caching.Redis.ReservedRedisKeyspaceExtensions
+static UiPath.Caching.Redis.ReservedRedisKeyspaceExtensions.ReserveRedisKeyspace(this Microsoft.Extensions.DependencyInjection.IServiceCollection! services, string! keyspace, string! owner) -> Microsoft.Extensions.DependencyInjection.IServiceCollection!
+*REMOVED*UiPath.Caching.Redis.RedisTypePrefixes
+*REMOVED*const UiPath.Caching.Redis.RedisTypePrefixes.Hash = "h" -> string!
+*REMOVED*const UiPath.Caching.Redis.RedisTypePrefixes.PubSub = "ps" -> string!
+*REMOVED*const UiPath.Caching.Redis.RedisTypePrefixes.Streams = "st" -> string!
+*REMOVED*const UiPath.Caching.Redis.RedisTypePrefixes.String = "s" -> string!
+UiPath.Caching.Redis.RedisKeyspaces
+const UiPath.Caching.Redis.RedisKeyspaces.Hash = "h" -> string!
+const UiPath.Caching.Redis.RedisKeyspaces.PubSub = "ps" -> string!
+const UiPath.Caching.Redis.RedisKeyspaces.Streams = "st" -> string!
+const UiPath.Caching.Redis.RedisKeyspaces.String = "s" -> string!

--- a/src/UiPath.Caching/Redis/DefaultRedisKeyStrategyFactory.cs
+++ b/src/UiPath.Caching/Redis/DefaultRedisKeyStrategyFactory.cs
@@ -4,29 +4,29 @@ public sealed class DefaultRedisKeyStrategyFactory : IRedisKeyStrategyFactory
 {
     public IRedisKeyStrategy Create(CacheOptions options, Type cacheType)
     {
-        string typePrefix;
+        string keyspace;
 
         if (typeof(ICache).IsAssignableFrom(cacheType))
         {
-            typePrefix = RedisTypePrefixes.String;
+            keyspace = RedisKeyspaces.String;
         }
         else if (typeof(IHashCache).IsAssignableFrom(cacheType))
         {
-            typePrefix = RedisTypePrefixes.Hash;
+            keyspace = RedisKeyspaces.Hash;
         }
         else
         {
             throw new ArgumentException($"Cache type {cacheType} is not supported by {nameof(DefaultRedisKeyStrategyFactory)}");
         }
 
-        return Create(options, typePrefix);
+        return Create(options, keyspace);
     }
 
     public IRedisKeyStrategy Create(CacheOptions options, string differentiator)
     {
-        var typePrefix = Guard.NotNullOrWhiteSpace(differentiator, nameof(differentiator));
+        var keyspace = Guard.NotNullOrWhiteSpace(differentiator, nameof(differentiator));
         var separator = Guard.NotWhiteSpace(options.Separator, nameof(options.Separator));
-        var prefix = string.Join(separator, Guard.NotNullOrWhiteSpace(options.AppShortName, nameof(options.AppShortName)), typePrefix);
+        var prefix = string.Join(separator, Guard.NotNullOrWhiteSpace(options.AppShortName, nameof(options.AppShortName)), keyspace);
         return options.ShardKeyEnabled ? new ShardPrefixRedisKeyStrategy(prefix, separator) : new PrefixRedisKeyStrategy(prefix, separator);
     }
 }

--- a/src/UiPath.Caching/Redis/RedisKeyspaces.cs
+++ b/src/UiPath.Caching/Redis/RedisKeyspaces.cs
@@ -1,6 +1,6 @@
 namespace UiPath.Caching.Redis;
 
-public static class RedisTypePrefixes
+public static class RedisKeyspaces
 {
     public const string String = "s";
     

--- a/src/UiPath.Caching/Redis/ReservedRedisKeyspace.cs
+++ b/src/UiPath.Caching/Redis/ReservedRedisKeyspace.cs
@@ -1,0 +1,180 @@
+namespace UiPath.Caching.Redis;
+
+/// <summary>A Redis keyspace a package occupies, so nothing else can be configured onto it.</summary>
+public interface IReservedRedisKeyspace
+{
+    string Keyspace { get; }
+
+    /// <summary>
+    /// Who occupies it. Also the identity a repeat reservation is matched on, so make it specific to the
+    /// package: "ICache", "ISetCache (UiPath.Caching.Queue)". Two packages sharing one owner string on one
+    /// keyspace read as the same package reserving twice.
+    /// </summary>
+    string Owner { get; }
+}
+
+internal sealed class ReservedRedisKeyspace : IReservedRedisKeyspace
+{
+    public ReservedRedisKeyspace(string keyspace, string owner, bool isDistributedCache = false)
+    {
+        Keyspace = SingleSegment(Guard.NotNullOrWhiteSpace(keyspace, nameof(keyspace)));
+        Owner = Guard.NotNullOrWhiteSpace(owner, nameof(owner));
+        IsDistributedCache = isDistributedCache;
+    }
+
+    /// <summary>
+    /// A keyspace fills one segment between <c>AppShortName</c> and the rest of the key. Letters and digits
+    /// only, so it cannot span segments under any punctuation separator: <c>"x"</c> and <c>"x:y"</c> would
+    /// otherwise both be reservable while a key of <c>"y:k"</c> under the first renders what <c>"k"</c>
+    /// renders under the second. <c>CacheOptions.Separator</c> may itself be alphanumeric, which this rule
+    /// cannot anticipate, so the pair is checked against the configured separator when the cache resolves.
+    /// </summary>
+    private static string SingleSegment(string keyspace) =>
+        keyspace.All(char.IsLetterOrDigit)
+            ? keyspace
+            : throw new ArgumentException(
+                $"Redis keyspace '{keyspace}' must be a single segment of letters and digits. It fills the slot between AppShortName and the rest of the key, so anything else risks overlapping another keyspace.",
+                nameof(keyspace));
+
+    public string Keyspace { get; }
+
+    public string Owner { get; }
+
+    /// <summary>Set only by <c>AddDistributedCache</c>: <see cref="Owner"/> is display text a caller could imitate.</summary>
+    public bool IsDistributedCache { get; }
+}
+
+public static class ReservedRedisKeyspaceExtensions
+{
+    private const string DistributedCacheOwner = "AddDistributedCache";
+
+    /// <summary>
+    /// Declares a keyspace this package occupies; call it from the package's own builder extension. The
+    /// keyspace is one segment of letters and digits. A different owner already on it is rejected, a repeat
+    /// by the same owner is ignored so a package can reserve from several registration methods, and keyspace
+    /// comparison is case-insensitive because the key strategy lowercases. <paramref name="owner"/> is
+    /// matched exactly, so qualify it with the package name.
+    /// </summary>
+    public static IServiceCollection ReserveRedisKeyspace(this IServiceCollection services, string keyspace, string owner)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(keyspace);
+        ArgumentNullException.ThrowIfNull(owner);
+        return services.Reserve(new ReservedRedisKeyspace(keyspace, owner));
+    }
+
+    /// <summary>
+    /// Reserves the keyspace <c>AddDistributedCache</c> takes with its differentiator. The reservation is
+    /// marked by type rather than by owner, which is display text a caller could imitate.
+    /// </summary>
+    internal static IServiceCollection ReserveDistributedCacheRedisKeyspace(this IServiceCollection services, string differentiator) =>
+        services.Reserve(new ReservedRedisKeyspace(differentiator, DistributedCacheOwner, isDistributedCache: true));
+
+    private static IServiceCollection Reserve(this IServiceCollection services, ReservedRedisKeyspace reservation)
+    {
+        // Materialized, so every descriptor is validated even when the match is found early.
+        var reserved = services.ReservedRedisKeyspaces().ToList();
+        if (reserved.FirstOrDefault(r => r.Covers(reservation.Keyspace)) is { } taken)
+        {
+            if (string.Equals(taken.Owner, reservation.Owner, StringComparison.Ordinal)
+                && taken.IsDistributedCache() == reservation.IsDistributedCache)
+            {
+                return services;
+            }
+
+            throw new InvalidOperationException(KeyspaceCollisionMessage(taken, reservation));
+        }
+
+        services.AddSingleton<IReservedRedisKeyspace>(reservation);
+        return services;
+    }
+
+    /// <summary>
+    /// The declarations made so far. Only instance registrations are visible before the container exists,
+    /// so a reservation added any other way would be enforced at resolution but not at registration.
+    /// </summary>
+    internal static IEnumerable<IReservedRedisKeyspace> ReservedRedisKeyspaces(this IServiceCollection services)
+    {
+        foreach (var descriptor in services.Where(d => d.ServiceType == typeof(IReservedRedisKeyspace)))
+        {
+            yield return descriptor.ImplementationInstance as ReservedRedisKeyspace ?? throw Unsupported();
+        }
+    }
+
+    /// <summary>Reservations that reached the container any other way, which the registration-time check never saw.</summary>
+    internal static IEnumerable<IReservedRedisKeyspace> Validated(this IEnumerable<IReservedRedisKeyspace> reserved) =>
+        reserved.Select(r => r as ReservedRedisKeyspace ?? throw Unsupported());
+
+    /// <summary>
+    /// The separator is only known once options bind, so this is where one keyspace containing another is
+    /// caught: with separator <c>'x'</c>, <c>"a"</c> and <c>"axb"</c> render the same key from <c>"bxk"</c>
+    /// and <c>"k"</c>.
+    /// </summary>
+    internal static IReadOnlyList<IReservedRedisKeyspace> ValidatedFor(
+        this IEnumerable<IReservedRedisKeyspace> reserved, char separator)
+    {
+        var all = reserved.Validated().ToList();
+        foreach (var outer in all)
+        {
+            var nested = all.Find(other => !ReferenceEquals(other, outer)
+                && other.Keyspace.StartsWith(outer.Keyspace + separator, StringComparison.OrdinalIgnoreCase));
+            if (nested is not null)
+            {
+                throw new InvalidOperationException(
+                    $"The Redis keyspace '{nested.Keyspace}' reserved by {nested.Owner} sits inside '{outer.Keyspace}' reserved by {outer.Owner} under the configured separator '{separator}', so the two would render the same key from different cache keys. Choose keyspaces that do not nest, or a separator that does not appear in them.");
+            }
+        }
+
+        return all;
+    }
+
+    private static InvalidOperationException Unsupported() =>
+        new("An IReservedRedisKeyspace is registered by something other than IServiceCollection.ReserveRedisKeyspace(keyspace, owner) — from a factory, an implementation type, or a custom implementation. Reservations made that way are invisible to the registration-time keyspace check, so they cannot be checked against each other. Register it with ReserveRedisKeyspace instead.");
+
+    internal static bool Covers(this IReservedRedisKeyspace reserved, string keyspace) =>
+        string.Equals(reserved.Keyspace, keyspace, StringComparison.OrdinalIgnoreCase);
+
+    internal static bool IsDistributedCache(this IReservedRedisKeyspace reserved) =>
+        reserved is ReservedRedisKeyspace { IsDistributedCache: true };
+
+    /// <summary>Whether <c>AddDistributedCache</c> already took a keyspace, enabled or not.</summary>
+    internal static bool HasDistributedCacheRedisKeyspace(this IServiceCollection services) =>
+        services.ReservedRedisKeyspaces().ToList().Exists(reserved => reserved.IsDistributedCache());
+
+    /// <summary>Names the differentiator when the distributed cache is one of the two sides, since that is the value the reader can change.</summary>
+    private static string KeyspaceCollisionMessage(IReservedRedisKeyspace taken, ReservedRedisKeyspace wanted)
+    {
+        if (wanted.IsDistributedCache)
+        {
+            return $"UiPathDistributedCacheOptions.RedisKeyDifferentiator '{wanted.Keyspace}' is the Redis keyspace reserved by {taken.Owner}, which would put the distributed cache in the same Redis keyspace. Choose another value.";
+        }
+
+        if (taken.IsDistributedCache())
+        {
+            return $"UiPathDistributedCacheOptions.RedisKeyDifferentiator '{taken.Keyspace}' is the Redis keyspace reserved by {wanted.Owner}, which would put the distributed cache in the same Redis keyspace. Choose another value.";
+        }
+
+        return $"{wanted.Owner} reserves the Redis keyspace '{wanted.Keyspace}', which {taken.Owner} already occupies. Two packages cannot share one keyspace: their keys would collide on Redis.";
+    }
+}
+
+/// <summary>
+/// Runs the separator-dependent keyspace checks when <see cref="CacheOptions"/> is first resolved, so they
+/// hold for package-to-package layouts and not only where the distributed cache probes them.
+/// </summary>
+internal sealed class ReservedRedisKeyspaceValidator(IEnumerable<IReservedRedisKeyspace> reserved)
+    : IValidateOptions<CacheOptions>
+{
+    public ValidateOptionsResult Validate(string? name, CacheOptions options)
+    {
+        try
+        {
+            reserved.ValidatedFor(options.Separator);
+            return ValidateOptionsResult.Success;
+        }
+        catch (InvalidOperationException ex)
+        {
+            return ValidateOptionsResult.Fail(ex.Message);
+        }
+    }
+}

--- a/tests/UiPath.Caching.Tests/Config/DistributedCacheRegistrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Config/DistributedCacheRegistrationTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -165,17 +166,441 @@ public class DistributedCacheRegistrationTests
     }
 
     [Theory]
-    [InlineData(RedisTypePrefixes.String)]
-    [InlineData(RedisTypePrefixes.Hash)]
-    [InlineData(RedisTypePrefixes.PubSub)]
-    [InlineData(RedisTypePrefixes.Streams)]
+    [InlineData(RedisKeyspaces.String)]
+    [InlineData(RedisKeyspaces.Hash)]
+    [InlineData(RedisKeyspaces.PubSub)]
+    [InlineData(RedisKeyspaces.Streams)]
     [InlineData("H")]
     [InlineData("ST")]
-    public void Redis_key_differentiator_colliding_with_an_application_prefix_fails_fast(string differentiator)
+    public void Redis_key_differentiator_colliding_with_an_application_keyspace_fails_fast(string differentiator)
     {
         var act = () => Build(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = differentiator);
 
         act.Should().Throw<InvalidOperationException>().WithMessage("*same Redis keyspace*");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Redis_key_differentiator_colliding_with_a_package_keyspace_fails_fast(bool packageRegisteredFirst)
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddCaching(b =>
+        {
+            b.AddMemory(_ => { });
+            if (packageRegisteredFirst)
+            {
+                b.Services.ReserveRedisKeyspace("zz", "IListCache (Some.Package)");
+            }
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "ZZ");
+            if (!packageRegisteredFirst)
+            {
+                b.Services.ReserveRedisKeyspace("zz", "IListCache (Some.Package)");
+            }
+        });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*reserved by IListCache (Some.Package)*same Redis keyspace*");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Reservation_and_differentiator_collide_across_separate_AddCaching_calls(bool packageRegisteredFirst)
+    {
+        var services = new ServiceCollection();
+
+        var act = () =>
+        {
+            if (packageRegisteredFirst)
+            {
+                services.ReserveRedisKeyspace("zz", "Some.Package");
+                services.AddCaching(b =>
+                {
+                    b.AddMemory(_ => { });
+                    b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "zz");
+                });
+            }
+            else
+            {
+                services.AddCaching(b =>
+                {
+                    b.AddMemory(_ => { });
+                    b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "zz");
+                });
+                services.ReserveRedisKeyspace("zz", "Some.Package");
+            }
+        };
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*same Redis keyspace*");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Collision_is_reported_even_when_caching_is_disabled(bool distributedFirst)
+    {
+        var services = new ServiceCollection();
+
+        var act = () =>
+        {
+            if (distributedFirst)
+            {
+                services.AddCaching(
+                    b =>
+                    {
+                        b.AddMemory(_ => { });
+                        b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "zz");
+                    },
+                    o => o.Enabled = false);
+                services.ReserveRedisKeyspace("zz", "Some.Package");
+            }
+            else
+            {
+                services.ReserveRedisKeyspace("zz", "Some.Package");
+                services.AddCaching(
+                    b =>
+                    {
+                        b.AddMemory(_ => { });
+                        b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "zz");
+                    },
+                    o => o.Enabled = false);
+            }
+        };
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*same Redis keyspace*");
+    }
+
+    [Fact]
+    public void Reservation_landing_on_the_distributed_differentiator_reports_the_same_collision()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b =>
+        {
+            b.AddMemory(_ => { });
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "se");
+        });
+
+        var act = () => services.ReserveRedisKeyspace("SE", "SomePackage");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*RedisKeyDifferentiator 'se' is the Redis keyspace reserved by SomePackage*same Redis keyspace*");
+    }
+
+    [Fact]
+    public void Layered_package_keyspace_is_free_while_that_package_is_not_registered()
+    {
+        using var provider = Build(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "se");
+
+        provider.GetRequiredService<IDistributedCache>().Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Default_redis_key_differentiator_reserved_by_a_package_fails_fast()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.AddCaching(b =>
+        {
+            b.Services.ReserveRedisKeyspace(UiPathDistributedCacheOptions.DefaultRedisKeyDifferentiator, "SomePackage");
+            b.AddMemory(_ => { });
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+        });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*reserved by SomePackage*");
+    }
+
+    [Fact]
+    public void Reserving_a_keyspace_again_for_the_same_owner_is_ignored()
+    {
+        var services = new ServiceCollection();
+
+        services.ReserveRedisKeyspace("x", "First").ReserveRedisKeyspace("X", "First");
+
+        services.Where(d => d.ServiceType == typeof(IReservedRedisKeyspace)).Should().ContainSingle()
+            .Which.ImplementationInstance.Should().BeAssignableTo<IReservedRedisKeyspace>()
+            .Which.Owner.Should().Be("First");
+    }
+
+    [Fact]
+    public void Package_naming_itself_after_the_distributed_cache_does_not_mask_the_collision()
+    {
+        var services = new ServiceCollection();
+        services.ReserveRedisKeyspace("zz", "AddDistributedCache");
+
+        var act = () => services.AddCaching(b =>
+        {
+            b.AddMemory(_ => { });
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "zz");
+        });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*same Redis keyspace*");
+    }
+
+    [Fact]
+    public void Reserving_an_occupied_keyspace_for_another_owner_fails_fast()
+    {
+        var services = new ServiceCollection();
+        services.ReserveRedisKeyspace("x", "First");
+
+        var act = () => services.ReserveRedisKeyspace("X", "Second");
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Second reserves the Redis keyspace 'X', which First already occupies*");
+    }
+
+    [Fact]
+    public void Second_AddDistributedCache_is_rejected_even_when_the_first_had_caching_disabled()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddMemory(_ => { });
+                b.AddDistributedCache(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "zz");
+            },
+            o => o.Enabled = false);
+
+        var act = () => services.AddCaching(b =>
+        {
+            b.AddMemory(_ => { });
+            b.AddDistributedCache(KnownCacheProviderNames.InMemory);
+        });
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*AddDistributedCache has already been called*");
+    }
+
+    [Fact]
+    public void Reservation_from_a_foreign_implementation_is_reported()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IReservedRedisKeyspace>(new ForeignKeyspace());
+
+        var act = () => services.ReserveRedisKeyspace("x", "First");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ReserveRedisKeyspace*");
+    }
+
+    private sealed class ForeignKeyspace : IReservedRedisKeyspace
+    {
+        public string Keyspace => "zz";
+
+        public string Owner => "Some.Package";
+    }
+
+    [Fact]
+    public void Reservation_registered_without_an_instance_is_reported()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IReservedRedisKeyspace>(_ => throw new UnreachableException());
+
+        var act = () => services.ReserveRedisKeyspace("x", "First");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ReserveRedisKeyspace*");
+    }
+
+    [Fact]
+    public void Key_strategy_that_rejects_another_packages_keyspace_does_not_fail_the_probe()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.ReserveRedisKeyspace("zz", "Some.Package");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
+                b.AddRedis(o => o.RedisKeyStrategyFactory = new PickyRedisKeyStrategyFactory("zz"));
+                b.AddDistributedCache(KnownCacheProviderNames.Redis);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void Key_strategy_that_fails_to_render_a_reserved_keyspace_surfaces()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.ReserveRedisKeyspace("zz", "Some.Package");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
+                b.AddRedis(o => o.RedisKeyStrategyFactory = new UnrenderableRedisKeyStrategyFactory("zz"));
+                b.AddDistributedCache(KnownCacheProviderNames.Redis);
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*cannot render*");
+    }
+
+    /// <summary>Builds a strategy for the keyspace but cannot render a key with it, which is a fault rather than a refusal.</summary>
+    private sealed class UnrenderableRedisKeyStrategyFactory(string unrenderable) : IRedisKeyStrategyFactory
+    {
+        private readonly DefaultRedisKeyStrategyFactory _inner = new();
+
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) => _inner.Create(options, cacheType);
+
+        public IRedisKeyStrategy Create(CacheOptions options, string differentiator) =>
+            string.Equals(differentiator, unrenderable, StringComparison.OrdinalIgnoreCase)
+                ? new ThrowingRedisKeyStrategy(differentiator)
+                : _inner.Create(options, differentiator);
+
+        private sealed class ThrowingRedisKeyStrategy(string keyspace) : IRedisKeyStrategy
+        {
+            public RedisKey GetRedisKey(CacheKey cacheKey) =>
+                throw new InvalidOperationException($"cannot render a key for {keyspace}");
+        }
+    }
+
+    /// <summary>Refuses to build a key for a keyspace it does not know, the shape the extending guide encourages.</summary>
+    private sealed class PickyRedisKeyStrategyFactory(string rejected) : IRedisKeyStrategyFactory
+    {
+        private readonly DefaultRedisKeyStrategyFactory _inner = new();
+
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) => _inner.Create(options, cacheType);
+
+        public IRedisKeyStrategy Create(CacheOptions options, string differentiator) =>
+            string.Equals(differentiator, rejected, StringComparison.OrdinalIgnoreCase)
+                ? throw new ArgumentException($"unknown keyspace {differentiator}", nameof(differentiator))
+                : _inner.Create(options, differentiator);
+    }
+
+    [Fact]
+    public void Nested_keyspaces_are_rejected_even_when_caching_is_disabled()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.ReserveRedisKeyspace("a", "Outer.Package");
+                b.Services.ReserveRedisKeyspace("axb", "Inner.Package");
+            },
+            o =>
+            {
+                o.AppShortName = "app";
+                o.Separator = 'x';
+                o.Enabled = false;
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*sits inside*Outer.Package*");
+    }
+
+    [Fact]
+    public void Nested_keyspaces_are_rejected_without_a_distributed_cache_registration()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.ReserveRedisKeyspace("a", "Outer.Package");
+                b.Services.ReserveRedisKeyspace("axb", "Inner.Package");
+                b.AddMemory(_ => { });
+            },
+            o =>
+            {
+                o.AppShortName = "app";
+                o.Separator = 'x';
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IOptions<CacheOptions>>().Value;
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*sits inside*Outer.Package*");
+    }
+
+    [Fact]
+    public void Keyspaces_that_nest_under_an_alphanumeric_separator_are_rejected_when_resolved()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.Services.ReserveRedisKeyspace("a", "Outer.Package");
+                b.Services.ReserveRedisKeyspace("axb", "Inner.Package");
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
+                b.AddRedis(_ => { });
+                b.AddDistributedCache(KnownCacheProviderNames.Redis);
+            },
+            o =>
+            {
+                o.AppShortName = "app";
+                o.Separator = 'x';
+            });
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<OptionsValidationException>().WithMessage("*sits inside*Outer.Package*");
+    }
+
+    [Theory]
+    [InlineData("x:y")]
+    [InlineData("x y")]
+    [InlineData("x-y")]
+    public void Reservation_spanning_more_than_one_segment_is_rejected(string keyspace)
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.ReserveRedisKeyspace(keyspace, "Some.Package");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*single segment of letters and digits*");
+    }
+
+    [Fact]
+    public void Redis_key_differentiator_spanning_more_than_one_segment_is_rejected()
+    {
+        var act = () => Build(KnownCacheProviderNames.InMemory, o => o.RedisKeyDifferentiator = "d:h");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*single segment of letters and digits*");
+    }
+
+    [Fact]
+    public void Blank_reservation_is_rejected()
+    {
+        var services = new ServiceCollection();
+
+        var act = () => services.ReserveRedisKeyspace(" ", "SomePackage");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Redis_key_strategy_landing_on_a_package_keyspace_is_rejected_when_resolved()
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(
+            b =>
+            {
+                b.AddRedisConnection(o => o.ConnectionString = "localhost:6379,abortConnect=false,connectTimeout=1000,syncTimeout=1000");
+                b.AddRedis(_ => { });
+                b.Services.ReserveRedisKeyspace("zz", "IListCache (Some.Package)");
+                b.AddDistributedCache(KnownCacheProviderNames.Redis, o => o.RedisKeyStrategyFactory = new FixedDifferentiatorRedisKeyStrategyFactory("zz"));
+            },
+            o => o.AppShortName = "app");
+        using var provider = services.BuildServiceProvider();
+
+        var act = () => provider.GetRequiredService<IDistributedCache>();
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*IListCache (Some.Package)*share one keyspace*");
+    }
+
+    /// <summary>A factory that ignores the differentiator it is given and lands on a fixed one.</summary>
+    private sealed class FixedDifferentiatorRedisKeyStrategyFactory(string differentiator) : IRedisKeyStrategyFactory
+    {
+        private readonly DefaultRedisKeyStrategyFactory _inner = new();
+
+        public IRedisKeyStrategy Create(CacheOptions options, Type cacheType) => _inner.Create(options, cacheType);
+
+        public IRedisKeyStrategy Create(CacheOptions options, string _) => _inner.Create(options, differentiator);
     }
 
     [Fact]
@@ -235,7 +660,7 @@ public class DistributedCacheRegistrationTests
             _inner.Create(options, "elsewhere");
 
         public IRedisKeyStrategy Create(CacheOptions options, string differentiator) =>
-            _inner.Create(options, RedisTypePrefixes.Hash);
+            _inner.Create(options, RedisKeyspaces.Hash);
     }
 
     /// <summary>
@@ -580,7 +1005,7 @@ public class DistributedCacheRegistrationTests
         var services = new ServiceCollection();
 
         var act = () => services.AddCaching(b => b.AddDistributedCache(
-            KnownCacheProviderNames.Redis, o => o.RedisKeyDifferentiator = RedisTypePrefixes.Hash));
+            KnownCacheProviderNames.Redis, o => o.RedisKeyDifferentiator = RedisKeyspaces.Hash));
 
         act.Should().Throw<InvalidOperationException>();
     }

--- a/tests/UiPath.Caching.Tests/Distributed/DistributedCacheRedisIntegrationTests.cs
+++ b/tests/UiPath.Caching.Tests/Distributed/DistributedCacheRedisIntegrationTests.cs
@@ -86,7 +86,7 @@ public class DistributedCacheRedisIntegrationTests(RedisContainerFixture fixture
         (await database.KeyTimeToLiveAsync(redisKey)).Should().NotBeNull();
 
         // Nothing lands in the application's own hash keyspace.
-        var applicationKey = $"{AppShortName}:{RedisTypePrefixes.Hash}:{key}";
+        var applicationKey = $"{AppShortName}:{RedisKeyspaces.Hash}:{key}";
         (await database.KeyExistsAsync(applicationKey)).Should().BeFalse();
 
         await cache.RemoveAsync(key, token);

--- a/tests/UiPath.Caching.Tests/QueueCacheCollectionExtensionsTests.cs
+++ b/tests/UiPath.Caching.Tests/QueueCacheCollectionExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using UiPath.Caching.Config;
 using UiPath.Caching.Queue.Config;
+using UiPath.Caching.Redis;
 
 namespace UiPath.Caching.Tests;
 
@@ -98,5 +99,30 @@ public class QueueCacheCollectionExtensionsTests
         services.Should().Contain(d =>
             d.ServiceType == typeof(IQueueCacheProvider) &&
             d.ImplementationType == typeof(RedisQueueCacheProvider));
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    [InlineData(true, false)]
+    public void Queue_registrations_reserve_the_set_keyspace_whether_or_not_the_backing_is_enabled(bool multilayer, bool backingEnabled)
+    {
+        var services = new ServiceCollection();
+        services.AddCaching(b =>
+        {
+            if (multilayer)
+            {
+                b.AddQueueInMemoryRedis(o => o.Enabled = backingEnabled);
+            }
+            else
+            {
+                b.AddQueueRedis(o => o.Enabled = backingEnabled);
+            }
+        });
+
+        var act = () => services.ReserveRedisKeyspace(RedisSetCache.RedisSetKeyspace, "Some.Package");
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*ISetCache (UiPath.Caching.Queue) already occupies*");
     }
 }

--- a/tests/UiPath.Caching.Tests/Redis/RedisCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisCacheTests.cs
@@ -1368,9 +1368,9 @@ public class RedisCacheTests(ITestContextAccessor testContextAccessor) : IAsyncL
     {
         _prefix = "test";
         _cacheKey = _fixture.Create<string>();
-        _redisKey = string.Join(':', _prefix, RedisTypePrefixes.String, _cacheKey).ToLowerInvariant();
+        _redisKey = string.Join(':', _prefix, RedisKeyspaces.String, _cacheKey).ToLowerInvariant();
         _multiKey = _fixture.Create<string>();
-        _redisMultiKey = string.Join(':', _prefix, RedisTypePrefixes.String, _multiKey).ToLowerInvariant();
+        _redisMultiKey = string.Join(':', _prefix, RedisKeyspaces.String, _multiKey).ToLowerInvariant();
         _clock = _fixture.Freeze<ISystemClock>();
         _fixture.Inject<TimeProvider>(new SystemClockTimeProvider(_clock));
         _clock.UtcNow.Returns(c => _now);

--- a/tests/UiPath.Caching.Tests/Redis/RedisCacheTryAddTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisCacheTryAddTests.cs
@@ -260,7 +260,7 @@ public class RedisCacheTryAddTests(ITestContextAccessor testContextAccessor) : I
     {
         const string prefix = "test";
         _cacheKey = _fixture.Create<string>();
-        _redisKey = string.Join(':', prefix, RedisTypePrefixes.String, _cacheKey).ToLowerInvariant();
+        _redisKey = string.Join(':', prefix, RedisKeyspaces.String, _cacheKey).ToLowerInvariant();
         _clock = _fixture.Freeze<ISystemClock>();
         _fixture.Inject<TimeProvider>(new SystemClockTimeProvider(_clock));
         _clock.UtcNow.Returns(_ => _now);

--- a/tests/UiPath.Caching.Tests/Redis/RedisHashCacheTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisHashCacheTests.cs
@@ -1492,7 +1492,7 @@ public class RedisHashCacheTests(ITestContextAccessor testContextAccessor) : IAs
     {
         _prefix = _fixture.Create<string>();
         _cacheKey = _fixture.Create<string>();
-        _redisKey = string.Join(':', _prefix, RedisTypePrefixes.Hash, _cacheKey).ToLowerInvariant();
+        _redisKey = string.Join(':', _prefix, RedisKeyspaces.Hash, _cacheKey).ToLowerInvariant();
 
         _database = _fixture.Freeze<IDatabase>();
         _transaction = _fixture.Freeze<ITransaction>();


### PR DESCRIPTION
Closes #130.

## The problem

`AddDistributedCache` compared `RedisKeyDifferentiator` against a hardcoded list of the core's own Redis keyspaces. A package layered on top was invisible to it, so a differentiator of `"se"` was accepted even though `UiPath.Caching.Queue`'s set cache already writes there, and the two would have shared one Redis keyspace.

## One registry, one rule

Packages declare the keyspaces they occupy through `IServiceCollection.ReserveRedisKeyspace(keyspace, owner)`. The core reserves its four, and `AddQueueRedis` / `AddQueueInMemoryRedis` reserve `"se"` whether or not that backing is enabled. **`AddDistributedCache` reserves its own differentiator the same way**, so a single rule answers every case: the second party to claim a keyspace is rejected, whoever it is.

That holds in either registration order, across separate `AddCaching` calls, and when `CacheOptions.Enabled` is false, because a keyspace collision is a configuration error rather than a runtime condition. Two packages claiming one keyspace is now rejected as well, where the later reservation used to be dropped silently; a repeat by the same owner is still ignored, since `AddQueueRedis` and `AddQueueInMemoryRedis` both reserve.

The resolution-time probe that guards a custom `IRedisKeyStrategyFactory` enumerates the same reservations. It skips any keyspace the factory refuses to build a key for, since a factory that rejects a keyspace cannot land on it, and it no longer emits duplicate probes when the type-based and keyspace-based lookups produce the same key.

## BREAKING: `RedisTypePrefixes` is now `RedisKeyspaces`

The library called one thing two names: a *type prefix* in the core, a *keyspace* in the reservation API. It is a keyspace everywhere now, which renames a shipped public type and the `IReservedRedisKeyspace.Keyspace` member. **The constant values are unchanged** (`"s"`, `"h"`, `"ps"`, `"st"`), so no Redis key changes shape and no data moves; already-compiled assemblies keep working and a recompile needs `RedisTypePrefixes` replaced with `RedisKeyspaces`. No obsolete forwarder, deliberately: keeping the old name alive would keep the second vocabulary alive. "Prefix" now means only an actual key prefix.

`ReservedRedisKeyspace`, the concrete class, is internal. `ReserveRedisKeyspace` is the supported way in, and a reservation registered any other way is now reported rather than being invisible to the registration-time check while still counting at resolution.

## Verification

Solution builds with zero warnings. Full suite passes on both frameworks, 1655 tests on .NET 10 and 1634 on .NET 8. Coverage of the new paths includes both registration orders, separate `AddCaching` calls, the disabled-caching path, same-owner versus different-owner reservation, a factory-registered reservation, and a key strategy that rejects another package's keyspace. The queue package's own reservations are pinned in its own test file rather than in the core suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fwLrS3Sbcen8v6iRkUaFB
