### PR TITLE
test: wait for the detection event, not the factory count, before asserting the rebuild

### DIFF
--- a/tests/UiPath.Caching.Tests/Redis/RedisConnectorStaleEndpointTests.cs
+++ b/tests/UiPath.Caching.Tests/Redis/RedisConnectorStaleEndpointTests.cs
@@ -442,10 +442,10 @@ public class RedisConnectorStaleEndpointTests
         h.Telemetry.Events.Should().BeEmpty();
 
         h.Multiplexer.ConfigureAsync(Arg.Any<TextWriter?>()).Returns(_ => h.Topology.Refreshed());
-        for (var i = 0; i < 8 && h.Factory.CreateCount == 1; i++)
+        for (var i = 0; i < 8 && !h.Telemetry.Events.Contains("Redis.StaleEndpointDetected"); i++)
         {
             h.Clock.Advance(TimeSpan.FromSeconds(30));
-            await h.Connector.ScanStaleEndpointsAsync(); // the remaining skipped intervals run out, then the refresh lands
+            await h.Connector.ScanStaleEndpointsAsync(); // the remaining skipped intervals run out, then the refresh lands; the event is recorded before the rebuild is queued
         }
         await h.OldDisposed.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
 


### PR DESCRIPTION
`Scan_BacksOffExponentially_WhileTheRefreshKeepsFailing_AndRecovers` failed once on CI (#158's Linux job) with the factory reporting three creations instead of two.

The recovery loop advanced the clock and scanned until `Factory.CreateCount` left 1, but that count is incremented inside `ForceReconnect`'s background task. When the loop iterated before that task had started, the next scan found the endpoint still stale and queued a second rebuild, which created a third multiplexer before noticing the swap and disposing it. The loop now stops on the `Redis.StaleEndpointDetected` event, which the triggering scan records synchronously before queuing the rebuild, and then awaits the old multiplexer's disposal as before.

Test only. Passed three consecutive local runs of the class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V9jRarnMLeZRZ5rYySRhkh
