### PR TITLE
docs: document the Azure and Queue packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,39 @@ Minimum `appsettings.json`:
 
 That's it. Everything else has a sensible default. Five-minute onboarding lives in [docs/quickstart.md](docs/quickstart.md); the full settings reference is in [docs/reference/settings.md](docs/reference/settings.md).
 
+### Optional add-ons
+
+Two packages plug into the same builder callback — Entra ID authentication for Azure Managed Redis, and set ("queue") caches:
+
+```bash
+dotnet add package UiPath.Caching.Azure
+dotnet add package UiPath.Caching.Queue
+```
+
+```csharp
+using UiPath.Caching.Queue.Config; // on top of the usings above; Entra auth needs no extra namespace
+
+builder.Services.AddCaching(
+    section,
+    b => b.AddRedisConnection().AddAzureEntraAuthentication()  // passwordless Redis, tokens auto-refreshed
+          .AddBroadcast().AddRedis().AddInMemoryRedis().AddMemory()
+          .AddQueueInMemoryRedis()                             // ISetCache / ISetCache<T>
+          .AddResilienceStrategies().AddCloudEvents(),
+    o => { section.Bind(o); o.AppShortName = "my-service"; });
+```
+
+With Entra the connection string is the endpoint alone, no access key: `"myamr.region.redis.azure.net:10000"`. An empty `Caching:AzureEntra` section uses `DefaultAzureCredential`; set `ManagedIdentityClientId` for a user-assigned identity. Set caches are injected like any other cache:
+
+```csharp
+public class InviteService(ISetCache<string> pending)
+{
+    public ValueTask<bool> TrackAsync(string tenant, string email, CancellationToken ct) =>
+        pending.AddAsync($"invites:{tenant}", email, ct);
+}
+```
+
+Details: [Entra recipe](docs/recipes/azure-entra-authentication.md), [set-cache settings](docs/reference/settings.md#queue-caches-uipathcachingqueue).
+
 ## Features
 
 **Resiliency**
@@ -71,8 +104,10 @@ That's it. Everything else has a sensible default. Five-minute onboarding lives 
 - **Per-topic options** — fine-grained overrides for fan-out, polling, backpressure, and the streams notify doorbell.
 - **Sharded Pub/Sub doorbell** (Redis 7+) — `NotifyEnabled` + `NotifyShardedPubSub` drop publish-to-deliver latency from `PollInterval` to network RTT without leaving the shard.
 - **Redis Cluster aware** — shard-key routing, master/replica split (writes to master, reads from replicas).
+- **Azure Managed Redis with Entra ID** — passwordless auth via managed identity, workload identity, or any `TokenCredential` (`UiPath.Caching.Azure`, `AddAzureEntraAuthentication()`). Tokens refresh automatically; TLS and RESP3 on by default. Other schemes (AWS IAM, a custom token source) plug into the same `IRedisConnectionConfigurator` seam without an Azure reference.
 
 **Advanced**
+- **Set caches (`ISetCache` / `ISetCache<T>`)** — Redis-set collections next to the key-value caches (`SADD` / `SPOP` / `SMEMBERS` / `SREM`), in `UiPath.Caching.Queue`, with memory, Redis, and multilayer backings. Despite the package name a set is unordered: `PopAsync` removes a random member, not the oldest.
 - **`IHashCache<T>`** — one entry, many fields, one TTL. Subset reads via `HMGET`; side-channel metadata via `HashCacheEntryOptions`. Bundled `GET + TTL` in a single transaction for hydrating-cache math.
 - **Named cache policies** — per-`ICache<T>` settings keyed by `typeof(T).FullName` (TTLs, jitter, rehydration, lock profile). Inherits from `DefaultCachePolicy` with `null`-means-inherit semantics.
 - **L2 jitter** — `JitterMaxDuration` spreads cluster-wide expirations after bulk writes.
@@ -106,7 +141,9 @@ flowchart LR
 | `UiPath.Caching` | Always — providers, topics, locks. |
 | `UiPath.Caching.Polly` | Resilience pipelines. Recommended. |
 | `UiPath.Caching.CloudEvents` | CloudEvents envelope for broadcast events. Recommended. |
-| `UiPath.Caching.Queue` | Set ("queue") support — `ISetCache`, registered per backing via `AddQueueMemory` / `AddQueueRedis` / `AddQueueInMemoryRedis`. |
+| `UiPath.Caching.OpenTelemetry` | OpenTelemetry adapter for `ICachingTelemetryProvider` — `ActivitySource` + `Meter` named `UiPath.Caching`. |
+| `UiPath.Caching.Azure` | Microsoft Entra ID authentication for Azure Managed Redis / Azure Cache for Redis. Adds `AddAzureEntraAuthentication()`. |
+| `UiPath.Caching.Queue` | Set ("queue") caches — `ISetCache` / `ISetCache<T>`, registered per backing via `AddQueueMemory` / `AddQueueRedis` / `AddQueueInMemoryRedis`. |
 
 ## Documentation
 
@@ -118,6 +155,9 @@ flowchart LR
 | Broadcast (per-topic, notify doorbell, sharded Pub/Sub) | [docs/how-to/broadcast.md](docs/how-to/broadcast.md) |
 | Hash cache (metadata, bundled GET+TTL) | [docs/how-to/hash-cache.md](docs/how-to/hash-cache.md) |
 | Telemetry + custom strategies | [docs/how-to/telemetry-and-strategies.md](docs/how-to/telemetry-and-strategies.md) |
+| Azure Managed Redis with Entra ID (and custom auth) | [docs/recipes/azure-entra-authentication.md](docs/recipes/azure-entra-authentication.md) |
+| Set ("queue") caches — model, coherence, pitfalls | [docs/concepts.md#set-caches](docs/concepts.md#set-caches) |
+| Set ("queue") caches — registration & settings | [docs/reference/settings.md#queue-caches-uipathcachingqueue](docs/reference/settings.md#queue-caches-uipathcachingqueue) |
 | Short copy-paste patterns | [docs/recipes/](docs/recipes/) |
 | Settings reference (every option, every default) | [docs/reference/settings.md](docs/reference/settings.md) |
 | Public interface surface | [docs/reference/interfaces.md](docs/reference/interfaces.md) |
@@ -129,6 +169,7 @@ flowchart LR
 
 - **.NET** — 8.0 and 10.0.
 - **Redis** — 6.0+. Redis 7.0+ required for sharded Pub/Sub (`SPUBLISH`/`SSUBSCRIBE`) on the streams notify doorbell.
+- **Azure Managed Redis / Azure Cache for Redis** — supported, with key-based or Entra ID authentication (`UiPath.Caching.Azure`).
 - **StackExchange.Redis** — pulled transitively; no direct dependency needed in consumers.
 
 ## License

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -7,14 +7,16 @@ moving parts in action; this page explains why they are shaped the way they are.
 Each section closes with a pointer to the place that carries the operational
 detail.
 
-The eight concepts covered here — providers, layers, topics, locks, policies,
-telemetry, the two API surfaces, and batch get-or-add — are largely independent
-of one another, but they compose. A single `GetOrAddAsync` call can touch all of them: the
-provider resolves which tiers to read and write, the layers determine what is
-already in memory vs. Redis, topics keep remote nodes in sync after the write,
-locks prevent redundant generator runs, the policy governs TTLs and rehydration,
-and telemetry records the outcome. Understanding each piece individually makes
-the composed behavior predictable.
+The nine concepts covered here — providers, layers, topics, locks, policies,
+telemetry, the two API surfaces, batch get-or-add, and set caches — are largely independent
+of one another, but they compose. A single `GetOrAddAsync` call can touch all of
+the first eight: the provider resolves which tiers to read and write, the layers
+determine what is already in memory vs. Redis, topics keep remote nodes in sync
+after the write, locks prevent redundant generator runs, the policy governs TTLs
+and rehydration, and telemetry records the outcome. Set caches stand apart — a
+separate package and a separate API shape, reusing the provider names and the
+options sections but taking no part in get-or-add. Understanding each piece
+individually makes the composed behavior predictable.
 
 ---
 
@@ -522,3 +524,134 @@ Callers whose keys already are their identity can skip the state pairing via a k
 method — see [recipes/batch-get-or-add.md](recipes/batch-get-or-add.md#keys-you-already-own).
 
 See also: [reference/interfaces.md](reference/interfaces.md), [recipes/batch-get-or-add.md](recipes/batch-get-or-add.md), [how-to/resilience.md#stampede-protection](how-to/resilience.md#stampede-protection).
+
+---
+
+## Set caches
+
+Everything above describes one key mapping to one value (`ICache<T>`) or to a bag of named fields
+(`IHashCache<T>`). There is a third data shape: a key mapping to an **unordered collection of unique
+members**, backed by a Redis set. It lives in the opt-in `UiPath.Caching.Queue` package and is
+reached through `ISetCache<T>` / `ISetCache`, created by `IQueueCacheFactory` rather than
+`ICacheFactory`.
+
+**The package name is misleading: a set is not a queue.** Members have no insertion order, and
+`PopAsync` removes a *random* member (`SPOP`), not the oldest. Nothing here delivers, acknowledges,
+or redelivers work items. It is a cache primitive for de-duplication, membership tests, and
+"claim any one of these" distribution.
+
+### Registration and backings
+
+The three registration methods mirror the core ones and share their configuration sections. Add the
+one that matches your backing — registering more than one is legal, and the factory then selects
+between them by provider name:
+
+```csharp
+b.AddQueueMemory();        // L1 only, no Redis prerequisite
+b.AddQueueRedis();         // L2 only; requires the core Redis services
+b.AddQueueInMemoryRedis(); // multilayer; also registers the Redis backing it uses as L2
+```
+
+Each one registers the `IQueueCacheProvider` for its backing, plus `IQueueCacheFactory`, `ISetCache`
+and `ISetCache<T>`. `AddQueueInMemoryRedis` contributes two providers rather than one, because the
+multilayer provider resolves its L2 tier through the Redis one — so `InMemoryRedis` and `Redis` both
+show up in `ProviderNames`. The factory picks a provider by `CacheOptions.DefaultCache`, exactly like the core
+cache factory, so a memory-only service must point `DefaultCache` at `InMemory`. When caching is
+off, or the backing you registered is disabled, the registration degrades to `NullSetCache` — reads
+report empty, writes report nothing written — so call sites need no conditional wiring. Resolution
+by name is looser than it looks, though: asking the factory for a provider that is unregistered or
+disabled does not hand back a no-op, it hands back whatever `CacheOptions.DefaultCache` resolves to,
+and only when that is missing or disabled too do you get `NullSetCache`. Disabling the `Redis`
+backing therefore does not, on its own, make an explicit `CreateSetCache("Redis")` inert.
+
+One combination to avoid outright: registering both queue backings with `DefaultCache` left at
+`InMemoryRedis` and the `Redis` one disabled. What you get depends on registration order, and
+neither outcome is the one you wanted.
+
+- `AddQueueInMemoryRedis()` followed by `AddQueueRedis()` throws on first use —
+  `InvalidOperationException`, *ValueFactory attempted to access the Value property of this
+  instance*. The multilayer provider builds its L2 by asking the factory for `Redis`; the disabled
+  provider sends that request on to the default, which is the multilayer provider itself, and it
+  re-enters its own lazy initializer.
+- `AddQueueRedis()` followed by `AddQueueInMemoryRedis()` turns the whole queue surface into no-ops.
+  The disabled registration installs the null factory first, and the later multilayer registration
+  cannot displace it.
+
+Registering `AddQueueInMemoryRedis()` on its own is unaffected, because `Caching:Redis:Enabled` binds
+`RedisSetCacheOptions` only when `AddQueueRedis` runs: the Redis tier that the multilayer backing
+co-registers stays enabled. If you want the Redis set cache off, leave the multilayer backing out
+rather than disabling the tier underneath it. Options bind from the same
+`Caching:InMemory` / `Caching:Redis` / `Caching:InMemoryRedis` sections as the core providers; see
+[reference/settings.md](reference/settings.md#queue-caches-uipathcachingqueue).
+
+On Redis the set cache keeps its own key namespace: the type-prefix slot holds `se`, where the
+single-value cache holds `s` and the hash cache holds `h`, so a set and a string cache can share a
+key name without colliding. Writes are pinned to the master, reads prefer a replica, and an add is a
+transaction that applies `SADD` and the key's expiry together. Like the core Redis caches, a Redis
+failure is logged and swallowed rather than thrown: reads report empty and writes report nothing
+written. Adds, pops and full-member reads check the connection first and return that same empty
+answer without issuing a command; the membership, count, remove and key-existence calls always
+issue theirs and reach the same catch when the connection is down.
+
+### Expiration applies to the key, not the member
+
+Redis sets have no per-member TTL. Every expiration — from the caller, from
+`CachePolicy.DistributedExpiration`, from the provider's `DefaultExpiration`, and finally from
+`CachePolicy.DefaultDistributedExpiration` — applies to the whole key, and **every add that carries
+at least one member re-applies it**, so adding one member resets the lifetime of the entire set.
+Usually that extends it; a caller who passes a deadline earlier than the current one shortens it
+instead. An add with an empty collection returns before the write, so it is not a way to refresh a
+set's time to live. On the Redis backing that chain
+always resolves to some deadline: a set never lives forever by default. Expiration arguments are non-nullable and taken at face value: a non-positive duration, or a
+deadline already in the past, raises `ArgumentOutOfRangeException` instead of being ignored.
+
+### What the multilayer set cache actually caches
+
+`AddQueueInMemoryRedis` puts an in-process snapshot in front of the Redis set, and its coherence
+model is **not** the one used by the key-value caches. There is no backplane here: no Streams
+message, no Pub/Sub invalidation. Local state is kept in step by three rules instead.
+
+- **A snapshot is created only by a full read that returns something.** `MembersAsync` on a local
+  miss fetches the set from Redis and stores the whole thing, bounded by `LocalMaxExpiration`; a
+  fetch that comes back empty stores nothing. While the connection is up, adds and removes update a
+  snapshot that already exists but never create one, so a write-only node keeps nothing locally.
+  Local-only mode is the exception: with `UseLocalOnlyWhenDisconnected` in force, adds do create
+  local state, capped by `LocalMaxExpirationDisconnected`.
+- **Reads are answered locally when a snapshot exists.** `MembersAsync`, `CountAsync`,
+  `ContainsItemAsync` and `ContainsAsync` are served from it and never reach Redis.
+- **Pops always go to Redis** while the connection is up, then remove what they popped from the
+  local snapshot. Two nodes therefore never pop the same member because one of them held a stale
+  view.
+
+The consequence worth internalizing: **another node's adds and removes are invisible to this node
+until its snapshot expires.** `LocalMaxExpiration` is the staleness bound, and it is the only one.
+It defaults to one minute, and it is nullable: `null` stores snapshots with no time bound at all,
+which leaves cross-node staleness unbounded and is the wrong setting for a multi-node deployment.
+If a set is written by many nodes and read for accuracy rather than for a hint, either keep that
+window short or use the `Redis` backing directly.
+
+When the connection monitor is enabled and Redis is unreachable, behavior follows the same options
+as the core multilayer cache: with `UseLocalOnlyWhenDisconnected` the snapshot keeps serving reads
+and absorbs writes; without it the snapshot is dropped and reads report empty rather than serving
+data that cannot be refreshed. Both switches are off by default. Note what
+`LocalMaxExpirationDisconnected` (thirty seconds) actually bounds: the local state a *disconnected
+add* writes, so that it dies soon after Redis returns. It does not shorten a snapshot fetched while
+connected, and disconnected pops and removes leave that deadline alone — an outage is not capped at
+thirty seconds of stale reads.
+
+### Retries and serialization
+
+Popping is destructive and not idempotent: a retried `SPOP` removes a *second* member, and the first
+one is lost with the failed reply. So pops do not share the `Write` pipeline. They run on the
+pipeline named by `RedisSetCacheOptions.ResilienceKeyName`, which defaults to none — opt in
+deliberately, and only where losing a member is acceptable. Everything else uses the standard
+`Read` and `Write` pipelines.
+
+Membership is decided on serialized bytes, in both tiers, which makes the serializer part of the
+contract: two equal values must serialize identically, or the same logical member is stored twice
+and the tiers disagree about what the set contains. Deterministic serialization matters here in a
+way it does not for the single-value caches.
+
+See also: [reference/interfaces.md](reference/interfaces.md#set-surface),
+[reference/settings.md](reference/settings.md#queue-caches-uipathcachingqueue),
+[how-to/resilience.md](how-to/resilience.md), [how-to/extending.md](how-to/extending.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ UiPath's internal multilayer caching library. L1 in-memory + L2 Redis, cross-nod
 | `UiPath.Caching.Polly` | Resilience pipelines around cache ops. Recommended. |
 | `UiPath.Caching.CloudEvents` | CNCF CloudEvents wrapper around broadcast events. Recommended. |
 | `UiPath.Caching.OpenTelemetry` | OpenTelemetry wiring for `ICachingTelemetryProvider` (`ActivitySource` + `Meter` named `UiPath.Caching`). |
+| `UiPath.Caching.Azure` | Microsoft Entra ID authentication for Azure Managed Redis / Azure Cache for Redis. |
+| `UiPath.Caching.Queue` | Set ("queue") caches on Redis sets — `ISetCache` / `ISetCache<T>`. |
 
 ## Pick your path
 
@@ -25,6 +27,8 @@ UiPath's internal multilayer caching library. L1 in-memory + L2 Redis, cross-nod
 - Per-field caching, side-channel metadata, bundled GET+TTL → [how-to/hash-cache.md](how-to/hash-cache.md).
 - OpenTelemetry adapter + Redis instrumentation, custom key/channel strategies → [how-to/telemetry-and-strategies.md](how-to/telemetry-and-strategies.md).
 - Adding a new cache provider, topic provider, or serializer → [how-to/extending.md](how-to/extending.md).
+- Set ("queue") caches: what they are, how they stay coherent → [concepts.md#set-caches](concepts.md#set-caches), [reference/settings.md#queue-caches-uipathcachingqueue](reference/settings.md#queue-caches-uipathcachingqueue).
+- Passwordless Azure Managed Redis → [recipes/azure-entra-authentication.md](recipes/azure-entra-authentication.md).
 
 **I need a short pattern I can paste.** → [recipes/](recipes/):
 
@@ -39,6 +43,7 @@ UiPath's internal multilayer caching library. L1 in-memory + L2 Redis, cross-nod
 - [custom-telemetry-provider.md](recipes/custom-telemetry-provider.md) — bridge `ICachingTelemetryProvider` to a host telemetry surface.
 - [opentelemetry-multiplexer-factory.md](recipes/opentelemetry-multiplexer-factory.md) — register OTel Redis instrumentation.
 - [redis-health-check.md](recipes/redis-health-check.md) — wire `RedisHealthCheck` into the ASP.NET health probe.
+- [azure-entra-authentication.md](recipes/azure-entra-authentication.md) — passwordless Azure Managed Redis via Entra ID, and the custom-auth seam.
 - [avoid-raw-iredisconnector.md](recipes/avoid-raw-iredisconnector.md) — three anti-patterns and their supported alternatives.
 
 **I need the full settings reference.** → [reference/settings.md](reference/settings.md) (one table per options class), [reference/interfaces.md](reference/interfaces.md) (public API surface), [reference/glossary.md](reference/glossary.md) (alphabetical term lookup).

--- a/docs/reference/interfaces.md
+++ b/docs/reference/interfaces.md
@@ -416,6 +416,124 @@ As on [`ICache`](#icache), `policy` is a **required** parameter on every policy-
 
 ---
 
+## Set surface
+
+### `ISetCache<T>`
+
+**Namespace:** `UiPath.Caching` — package `UiPath.Caching.Queue`
+
+```csharp
+public interface ISetCache<T>
+{
+    string Name { get; }
+
+    ValueTask<bool> AddAsync(CacheKey cacheKey, T item, CancellationToken token = default);
+
+    ValueTask<long> AddAsync(CacheKey cacheKey, IEnumerable<T> items, CancellationToken token = default);
+
+    ValueTask<long> AddAsync(CacheKey cacheKey, IEnumerable<T> items, TimeSpan expiration, CancellationToken token = default);
+
+    ValueTask<long> AddAsync(CacheKey cacheKey, IEnumerable<T> items, DateTimeOffset expiration, CancellationToken token = default);
+
+    ValueTask<T?> PopAsync(CacheKey cacheKey, CancellationToken token = default);
+
+    ValueTask<IReadOnlyCollection<T?>> PopAsync(CacheKey cacheKey, long count, CancellationToken token = default);
+
+    ValueTask<IReadOnlyCollection<T?>> MembersAsync(CacheKey cacheKey, CancellationToken token = default);
+
+    ValueTask<bool> ContainsItemAsync(CacheKey cacheKey, T item, CancellationToken token = default);
+
+    ValueTask<long> CountAsync(CacheKey cacheKey, CancellationToken token = default);
+
+    ValueTask<bool> RemoveItemAsync(CacheKey cacheKey, T item, CancellationToken token = default);
+
+    ValueTask<long> RemoveItemsAsync(CacheKey cacheKey, IEnumerable<T> items, CancellationToken token = default);
+
+    ValueTask<bool> RemoveAsync(CacheKey cacheKey, CancellationToken token = default);
+
+    ValueTask<bool> ContainsAsync(CacheKey cacheKey, CancellationToken token = default);
+}
+```
+
+`ISetCache<T>` is the typed set surface: one cache key holds an unordered collection of **unique** members, backed by a Redis set (`SADD` / `SPOP` / `SMEMBERS` / `SISMEMBER` / `SCARD` / `SREM`, plus `DEL` and `EXISTS` for the key itself). It is the third data shape in the library, next to the single-value [`ICache<T>`](#icachet) and the field-addressable [`IHashCache<T>`](#ihashcachet), and it ships in its own opt-in package.
+
+**Despite the `Caching.Queue` package name, a set is not a queue.** Members have no insertion order, and `PopAsync` removes a *random* member (`SPOP`), not the oldest or the newest. Code that needs FIFO or LIFO ordering must not be built on this surface.
+
+Uniqueness and membership are decided on the **serialized** form of a member, so `T` must serialize deterministically: two equal values that serialize to different bytes are both stored, and the memory and Redis tiers then disagree about membership. See [how-to/extending.md](../how-to/extending.md) on serializers.
+
+Like the other typed surfaces, `SetCache<T>` resolves its `CachePolicy` by `typeof(T).FullName` and applies an `ICacheKeyStrategy` to every key. Only `CachePolicy.DistributedExpiration` participates: Redis sets carry no per-member TTL, so expiration always applies to the whole key, and **every add that carries at least one member re-applies it** — adding one member resets the lifetime of the entire set, while an add with an empty collection returns before the write and refreshes nothing. The `expiration` parameters are non-nullable and taken at face value: a duration that is not strictly positive, or a deadline that has already passed, raises `ArgumentOutOfRangeException` rather than being ignored. Blocking forwarders (`Add`, `Pop`, `Members`, `Count`, `Remove`, …) live on `SetCacheSyncExtensions`.
+
+DI registers `ISetCache<T>` as transient over the **default** provider (`CacheOptions.DefaultCache`). To reach a specific backing, go through [`IQueueCacheFactory`](#iqueuecachefactory).
+
+**Use this when:**
+
+- You need set semantics in the cache: de-duplication, membership tests, or "claim one of these" distribution where order does not matter.
+- You want compile-time type safety and automatic `CachePolicy` resolution for the member type.
+
+**Don't use this when:**
+
+- You need ordering, or delivery with acknowledgement and redelivery — this is a cache primitive, not a message queue. Use the broadcast topics or a real queue.
+- One key maps to one value ([`ICache<T>`](#icachet)) or to named fields ([`IHashCache<T>`](#ihashcachet)).
+- The member type varies per call — use [`ISetCache`](#isetcache).
+
+**See also:** [`ISetCache`](#isetcache), [`IQueueCacheFactory`](#iqueuecachefactory), [Concepts: set caches](../concepts.md#set-caches), [Settings: queue caches](settings.md#queue-caches-uipathcachingqueue)
+
+---
+
+### `ISetCache`
+
+**Namespace:** `UiPath.Caching` — package `UiPath.Caching.Queue`
+
+```csharp
+public interface ISetCache : IDisposable
+{
+    string Name { get; }
+
+    ValueTask<bool> AddAsync<T>(CacheKey cacheKey, T item, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<long> AddAsync<T>(CacheKey cacheKey, IEnumerable<T> items, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<long> AddAsync<T>(CacheKey cacheKey, IEnumerable<T> items, TimeSpan expiration, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<long> AddAsync<T>(CacheKey cacheKey, IEnumerable<T> items, DateTimeOffset expiration, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<T?> PopAsync<T>(CacheKey cacheKey, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<IReadOnlyCollection<T?>> PopAsync<T>(CacheKey cacheKey, long count, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<IReadOnlyCollection<T?>> MembersAsync<T>(CacheKey cacheKey, CachePolicy? policy, CancellationToken token = default);
+
+    ValueTask<bool> ContainsItemAsync<T>(CacheKey cacheKey, T item, CancellationToken token = default);
+
+    ValueTask<long> CountAsync<T>(CacheKey cacheKey, CancellationToken token = default);
+
+    ValueTask<bool> RemoveItemAsync<T>(CacheKey cacheKey, T item, CancellationToken token = default);
+
+    ValueTask<long> RemoveItemsAsync<T>(CacheKey cacheKey, IEnumerable<T> items, CancellationToken token = default);
+
+    ValueTask<bool> RemoveAsync<T>(CacheKey cacheKey, CancellationToken token = default);
+
+    ValueTask<bool> ContainsAsync<T>(CacheKey cacheKey, CancellationToken token = default);
+}
+```
+
+`ISetCache` is the dynamic-member-type counterpart of [`ISetCache<T>`](#isetcachet). The member type is a method-level generic, and the `CachePolicy` is passed per call — `null` means "no policy", so the provider's configured defaults apply. `SetCacheExtensions` supplies overloads without the `policy` parameter for the common case. DI registers it as a singleton over the default provider; the typed wrapper is a thin adapter over this interface.
+
+The no-op implementation is `NullSetCache`: reads report empty and writes report nothing written. You get it when caching is disabled, and when neither the requested provider nor `CacheOptions.DefaultCache` resolves to an enabled one — asking for a disabled backing by name falls back to the default provider rather than to a no-op. It still rejects a member type the library refuses to cache, throwing `NotCacheableException` on every member, but validates nothing else — expirations in particular pass unchecked.
+
+**Use this when:**
+
+- Framework-level glue stores members whose type is not known until call time.
+- You are implementing or decorating a set-cache provider.
+
+**Don't use this when:**
+
+- The member type is fixed — [`ISetCache<T>`](#isetcachet) gives you policy resolution and a key strategy for free.
+
+**See also:** [`ISetCache<T>`](#isetcachet), [`IQueueCacheFactory`](#iqueuecachefactory), [Concepts: set caches](../concepts.md#set-caches)
+
+---
+
 ## Factory surface
 
 ### `ICacheFactory`
@@ -453,6 +571,37 @@ public interface ICacheFactory : IDisposable
 - You need broadcast (pub/sub) functionality — use [`ITopicFactory`](#itopicfactory) instead.
 
 **See also:** [`ICacheProvider`](../concepts.md), [`ITopicFactory`](#itopicfactory), [Quickstart](../quickstart.md), [Concepts](../concepts.md)
+
+---
+
+### `IQueueCacheFactory`
+
+**Namespace:** `UiPath.Caching` — package `UiPath.Caching.Queue`
+
+```csharp
+public interface IQueueCacheFactory : IDisposable
+{
+    IEnumerable<string> ProviderNames { get; }
+
+    ISetCache CreateSetCache(string? providerName = null);
+
+    void AddProvider(IQueueCacheProvider provider);
+}
+```
+
+`IQueueCacheFactory` is the queue package's counterpart to [`ICacheFactory`](#icachefactory): the same shape over a separate provider registry, because set support is opt-in and the core factory knows nothing about it. `CreateSetCache` returns the untyped [`ISetCache`](#isetcache) for a named provider; the `CreateSetCache<T>` extension method wraps it as [`ISetCache<T>`](#isetcachet). A provider name that is omitted, unregistered, or registered but disabled falls back to `CacheOptions.DefaultCache`, and then to `NullSetCache` when that one is missing or disabled too. Read `ISetCache.Name` to see which provider you actually got. One configuration makes resolution throw rather than fall back: `AddQueueInMemoryRedis()` followed by a disabled `AddQueueRedis()`, with `DefaultCache` at `InMemoryRedis`. The multilayer provider's request for `Redis` resolves to the default, which is itself, and its lazy initializer throws on re-entry. See [Concepts: set caches](../concepts.md#set-caches) for the reverse order, which fails differently.
+
+**Use this when:**
+
+- You need a set cache from a specific backing rather than the default one.
+- A test or multi-tenant scenario registers providers at runtime via `AddProvider`.
+
+**Don't use this when:**
+
+- You already hold an injected `ISetCache<T>` on the default provider.
+- You need the single-value or hash surfaces — those come from [`ICacheFactory`](#icachefactory).
+
+**See also:** [`ICacheFactory`](#icachefactory), [`ISetCache<T>`](#isetcachet), [Settings: queue caches](settings.md#queue-caches-uipathcachingqueue)
 
 ---
 


### PR DESCRIPTION
One commit, docs only. Neither add-on package was discoverable from the front page, and the set-cache surface was undocumented.

## 1. Point the front page at the Azure and Queue packages

The README never mentioned `UiPath.Caching.Azure`, gave `UiPath.Caching.Queue` a single packages-table row, and omitted `UiPath.Caching.OpenTelemetry` from that table altogether.

- **Quick Start → "Optional add-ons"** — install commands for both packages, one `AddCaching` callback wiring Entra auth and set caches together, and an injected `ISetCache<string>` example. Notes that with Entra the connection string is the bare endpoint, no access key.
- **Feature bullets** — Entra-authenticated Azure Managed Redis under *Distribution* (automatic token refresh, and the `IRedisConnectionConfigurator` seam for non-Azure schemes); set caches under *Advanced*, with the caveat that a set is unordered.
- **Packages table** — added the Azure and OpenTelemetry rows, expanded the Queue row.
- **Documentation table** — rows linking the Entra recipe, the new concepts section, and the queue-cache settings section.
- **Requirements** — Azure Managed Redis / Azure Cache for Redis, key-based or Entra authentication.

## 2. Document the set-cache surface

The queue package had options tables and scattered footnotes, but the mental-model page never mentioned that a third data shape exists, and the interface reference, which claims to cover the public surface, had no entry for it.

- **`docs/concepts.md` → "Set caches"** — what a set cache is and why it is not a queue, the three registration methods and their backings, the `se` Redis key namespace and the swallow-and-log failure behavior, key-scoped expiration that every add re-applies, and the multilayer coherence model.
- **The multilayer part is the load-bearing one.** There is no backplane, so a snapshot is created only by a full read, adds and removes maintain an existing snapshot without creating one, pops always go to Redis, and `LocalMaxExpiration` is the only bound on how stale this node's view of another node's writes can be. That differs from the key-value multilayer cache, and a reader who assumes Streams invalidation applies here would be wrong.
- **`docs/reference/interfaces.md` → "Set surface"** — entries for `ISetCache<T>` and `ISetCache`, plus `IQueueCacheFactory` under the factory surface, each in the existing use / don't-use format.
- **Also written down:** pops run on their own resilience pipeline, defaulting to none, because a retried `SPOP` removes a second member and loses the first; and membership is decided on serialized bytes, so the serializer must be deterministic.

`docs/index.md` gets the matching package rows and path entries.

## Verification

Every relative link and heading anchor across the four changed files was checked mechanically and resolves. Statements about behavior were taken from the implementation, not from the existing prose: `MultilayerSetCache`, `MemorySetCache`, `RedisSetCache`, and `QueueCacheCollectionExtensions`.

No code or public API change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fwLrS3Sbcen8v6iRkUaFB
