### PR TITLE
fix(cache): forward the token in multi-key RemoveAsync, clear the CI build warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -366,6 +366,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Fixed
 
+- **Multi-key `RemoveAsync` honors its cancellation token again.** The `CacheKey[]` overload built
+  each entry's options without the token, so an already-cancelled call did the work anyway and only
+  noticed at the removal itself. It now forwards the token, matching the single-key overload. The
+  rest of this change is build-warning cleanup with no behavior change: the periodic-timer loops in
+  `CacheMemoryMonitor` and the stream health maintainer, and the planned-maintenance probe task, now
+  say explicitly that they opt out of token propagation, each with the reason — disposal is what
+  stops the loops, and the probe delegate must always run so its `finally` clears the in-progress
+  flag. Test fakes moved off the obsolete `RedisServerException(string)` constructor.
+
 - **Stale endpoint detection works under the default `allowAdmin=false`.** The membership check
   issued `CLUSTER NODES`, which StackExchange.Redis refuses client-side unless admin mode is on, so on
   a default connection every scan recorded a `RedisCommandException` and never reconnected. The scan

--- a/src/UiPath.Caching/Broadcast/Redis/RedisStreamHealthMaintainer.cs
+++ b/src/UiPath.Caching/Broadcast/Redis/RedisStreamHealthMaintainer.cs
@@ -71,7 +71,10 @@ public partial class RedisStreamHealthMaintainer : IHostedService
 
     private async Task Start()
     {
-        while (!_cancellationToken.IsCancellationRequested && await _timer!.WaitForNextTickAsync() && await _semaphore.WaitAsync(0))
+        // Disposing the timer in StopAsync is what ends this loop, without an OperationCanceledException.
+        while (!_cancellationToken.IsCancellationRequested
+            && await _timer!.WaitForNextTickAsync(CancellationToken.None)
+            && await _semaphore.WaitAsync(0, CancellationToken.None))
         {
             await CheckStreamsAsync(_cancellationToken).ConfigureAwait(false);
         }

--- a/src/UiPath.Caching/CacheMemoryMonitor.cs
+++ b/src/UiPath.Caching/CacheMemoryMonitor.cs
@@ -30,7 +30,8 @@ internal sealed class CacheMemoryMonitor : IDisposable
 
     private async Task StartMonitor()
     {
-        while (!(_disposed || _cancelationToken.IsCancellationRequested) && await _timer.WaitForNextTickAsync())
+        // Disposing the timer in Dispose is what ends this loop, without an OperationCanceledException.
+        while (!(_disposed || _cancelationToken.IsCancellationRequested) && await _timer.WaitForNextTickAsync(CancellationToken.None))
         {
             var currentStats = _memoryCache.GetCurrentStatistics();
             if (currentStats == null)

--- a/src/UiPath.Caching/MultilayerCache.cs
+++ b/src/UiPath.Caching/MultilayerCache.cs
@@ -831,7 +831,7 @@ internal sealed partial class MultilayerCache : MultilayerCacheBase, ICache
     public ValueTask<bool> RemoveAsync<T>(CacheKey[] cacheKey, CancellationToken token = default)
     {
         NotCacheableException.ThrowIfNotCacheable<T>();
-        var options = cacheKey.Select(k => _entryBuilder.BuildEntryOptions<T>(k, default)).ToArray();
+        var options = cacheKey.Select(k => _entryBuilder.BuildEntryOptions<T>(k, default, token)).ToArray();
         return RemoveAsync<T>(options, token);
     }
 

--- a/src/UiPath.Caching/Redis/RedisPlannedMaintenance.cs
+++ b/src/UiPath.Caching/Redis/RedisPlannedMaintenance.cs
@@ -263,6 +263,8 @@ public sealed class RedisPlannedMaintenance : IRedisPlannedMaintenance, IHostedS
                     InProgress = false;
                     _telemetryProvider.TrackEvent("Redis.MaintenanceEnded");
                 }
-            });
+            },
+            // Never skip the delegate: its finally disposes the linked source and clears InProgress.
+            CancellationToken.None);
     }
 }

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamSubjectWriterTests.cs
@@ -232,7 +232,7 @@ public class RedisStreamSubjectWriterTests : IAsyncLifetime
         _database.StreamReadGroupAsync(_context.Topic, _context.ConsumerGroup, _context.ConsumerName, ">", _context.PollBatchSize)
             .ThrowsAsyncForAnyArgs(_ => throw new RedisException("NOGROUP unknown group"));
         _database.StreamCreateConsumerGroupAsync(_context.Topic, _context.ConsumerGroup, Arg.Any<RedisValue?>())
-            .ThrowsAsyncForAnyArgs(_ => { createCalled.TrySetResult(); throw new RedisServerException(BusyGroupMessage); });
+            .ThrowsAsyncForAnyArgs(_ => { createCalled.TrySetResult(); throw new RedisServerException(RedisErrorKind.None, CommandFlags.None, BusyGroupMessage); });
         _database.ClearReceivedCalls();
 
         var fetchTask = Sut.FetchTask;

--- a/tests/UiPath.Caching.Tests/Broadcast/RedisStreamsTopicTests.cs
+++ b/tests/UiPath.Caching.Tests/Broadcast/RedisStreamsTopicTests.cs
@@ -47,7 +47,7 @@ public class RedisStreamsTopicTests(ITestContextAccessor testContextAccessor) : 
         _database.StreamCreateConsumerGroup(
                 Arg.Any<RedisKey>(),
                 Arg.Any<RedisValue>(),
-                StreamPosition.NewMessages).Throws(new RedisServerException("BUSYGROUP Consumer Group name already exists"));
+                StreamPosition.NewMessages).Throws(new RedisServerException(RedisErrorKind.None, CommandFlags.None, "BUSYGROUP Consumer Group name already exists"));
         Action act = () => Sut.Subscribe(observer);
         act.Should().NotThrow();
     }
@@ -77,7 +77,7 @@ public class RedisStreamsTopicTests(ITestContextAccessor testContextAccessor) : 
         _database.StreamCreateConsumerGroup(
                 Arg.Any<RedisKey>(),
                 Arg.Any<RedisValue>(),
-                StreamPosition.NewMessages).Throws(new RedisServerException(_fixture.Create<string>()));
+                StreamPosition.NewMessages).Throws(new RedisServerException(RedisErrorKind.None, CommandFlags.None, _fixture.Create<string>()));
         Action act = () => Sut.Subscribe(observer);
         act.Should().Throw<Exception>();
     }

--- a/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
+++ b/tests/UiPath.Caching.Tests/UiPath.Caching.Tests.csproj
@@ -9,6 +9,8 @@
     <NoWarn>$(NoWarn);NU1608</NoWarn>
     <!-- SER305/SER306 flag awaiting a queued or fire-and-forget command; here those awaits are NSubstitute Received() checks on a mock. -->
     <NoWarn>$(NoWarn);SER305;SER306</NoWarn>
+    <!-- SER007 marks RedisErrorKind experimental; the non-obsolete RedisServerException ctor needs it, and these are test fakes. -->
+    <NoWarn>$(NoWarn);SER007</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Why

CI annotates eight analyzer warnings on every pull request. None belong to the branch that surfaces them, so they get carried from PR to PR and read as noise. One of the eight is a real defect.

## The defect

`MultilayerCache.RemoveAsync(CacheKey[], token)` built each entry's options **without** the token, while the single-key overload passes it. `CacheEntryBuilder.BuildEntryOptions` calls `ThrowIfCancellationRequested`, so an already-cancelled multi-key removal did the key-strategy and topic-key work anyway and only noticed at the removal itself. Now it forwards the token.

## The rest, no behavior change

- **Periodic-timer loops** in `CacheMemoryMonitor` and `RedisStreamHealthMaintainer` pass `CancellationToken.None` explicitly. Disposal is what ends them: `Dispose` / `StopAsync` disposes the timer, which completes the pending wait with `false`. Propagating the token would swap a clean exit for an `OperationCanceledException`. Each site says so in a comment. The health maintainer's semaphore wait has a zero timeout, so it never blocks either.
- **The planned-maintenance probe task** passes `CancellationToken.None` to `Task.Run` deliberately. Its token is already on a `CancelAfter` timer, and a token that won the race against scheduling would skip the delegate, leaking the linked source and leaving `InProgress` stuck true, which blocks every later probe. The delegate must always run so its `finally` clears the flag.
- **Test fakes** use the non-obsolete `RedisServerException` constructor. Its `RedisErrorKind` argument is experimental (`SER007`), suppressed in the test project next to the `SER305`/`SER306` suppressions already there. The production paths match on message text, so `RedisErrorKind.None` is faithful to what these fakes exercise.

## One finding rejected

The analyzer wants the null-forgiving operator gone from `RedisStreamsTopic` line 120, saying the compiler already knows the expression is non-null. It does not: removing it makes the compiler report `CS8604`, because `RedisKey` converts to a nullable `string` and the telemetry method takes a non-nullable one. The operator is load-bearing, so the code is unchanged.

## Verification

Solution builds with zero warnings, where it previously emitted eight. Full suite passes on both frameworks, 1636 tests on .NET 10 and 1615 on .NET 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fwLrS3Sbcen8v6iRkUaFB
