### PR TITLE
chore: turn off the overload-adjacency rule the caches deliberately break

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -443,6 +443,10 @@ dotnet_diagnostic.S107.severity = none
 dotnet_diagnostic.CA1016.severity = none
 dotnet_diagnostic.S3904.severity = none
 
+# S4136: All method overloads should be adjacent. The caches group each set of overloads with the private
+# Core helper they delegate to, so single-key and batch groups of the same name are deliberately apart.
+dotnet_diagnostic.S4136.severity = none
+
 csharp_using_directive_placement = outside_namespace:silent
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_prefer_method_group_conversion = true:silent


### PR DESCRIPTION
## Why

`S4136` ("All *X* method overloads should be adjacent") fires six times, in `MultilayerCache`, `MultilayerHashCache`, `RedisCache` and `RedisHashCache`. None of them is new. Because GitHub annotates warnings on changed files, every pull request that touches one of those files carries them, which is where this came from: PR #160 shows all six and introduced none.

## Why not reorder instead

The layout the rule objects to is deliberate. Each group of overloads is followed by the private `Core` helper it delegates to:

```csharp
public ValueTask<T?> GetOrAddAsync<T>(...);            // single-key group
public ValueTask<T?> GetOrAddAsync<T>(..., TimeSpan);
private ValueTask<T?> GetOrAddCoreAsync<T>(...);       // the helper those three share
public ValueTask<...[]> GetOrAddAsync<T, TState>(...); // batch group
```

Making the two groups adjacent means either moving the helpers away from the overloads they serve, or interleaving single-key and batch code. Both read worse than the warning, so the rule is switched off with that reason recorded next to it, in the same style as the other rules the repository already disables.

## Verification

Solution builds clean. Behavior unchanged: this is one `.editorconfig` entry. CI on this pull request is the check that the six annotations are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fwLrS3Sbcen8v6iRkUaFB
