### PR TITLE
refactor(cache): make the size provider a field, since that is what it is

### DIFF
--- a/src/UiPath.Caching/MemoryCacheSetter.cs
+++ b/src/UiPath.Caching/MemoryCacheSetter.cs
@@ -16,13 +16,12 @@ internal abstract class MemoryCacheSetter(
         )
 {
     private readonly KeyMasker _masker = masker ?? KeyMasker.Off;
+    private readonly ICacheEntrySizeProvider _sizeProvider = memoryCacheOptions.SizeProvider ?? new DefaultCacheEntrySizeProvider();
 
     private const string EventRefreshMetadataFailed = "Caching." + nameof(MemoryCacheSetter) + "." + nameof(RefreshMetadata) + ".Failed";
     private const string PropCacheKey = "CacheKey";
     private const string PropTopicKey = "TopicKey";
     private const string PropTransportId = "TransportId";
-
-    private ICacheEntrySizeProvider SizeProvider { get; } = memoryCacheOptions.SizeProvider ?? new DefaultCacheEntrySizeProvider();
 
     protected TimeProvider Clock { get; } = clock;
 
@@ -43,7 +42,7 @@ internal abstract class MemoryCacheSetter(
             memOptions.RegisterPostEvictionCallback(PostEviction, token);
             if(memoryCacheOptions.SizeLimit.HasValue)
             {
-                memOptions.SetSize(SizeProvider.GetSize(item));
+                memOptions.SetSize(_sizeProvider.GetSize(item));
             }
             memoryCache.Set(options.CacheKey, item, memOptions);
             return true;


### PR DESCRIPTION
`MemoryCacheSetter.SizeProvider` was a get-only private property holding a value resolved once from the options:

```csharp
private ICacheEntrySizeProvider SizeProvider { get; } = memoryCacheOptions.SizeProvider ?? new DefaultCacheEntrySizeProvider();
```

No computation, no interception, nothing a property buys over a field. It is now `_sizeProvider`, declared with the other fields — which also keeps it out of the property block that the ordering rules group together.

Came out of counting property accessibilities across `src` while sizing up the StyleCop ordering rules: 398 properties, of which exactly four are private. The other three earn it — `RedisStreamHealthMaintainer.Database`, `RedisStreamSubjectWriter.ContinueLoop` and `RedisConnector.ConnectionMultiplexer` all compute on every read, which is what a private property is for. This was the only one holding state.

`IMemoryCacheOptions.SizeProvider`, the public option it reads from, is untouched.

Build clean, full suite green: 1704 on net10, 1683 on net8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NsPw6MZHPGmpbo6WDuLzF1
