### PR TITLE
fix(cache): refuse configuration written under a key 2.0 removed, and document the 1.x to 2.0 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,9 +317,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   `TryAddAsync<T>(key, value, token)`, `AddAsync<T>(key, item, token)`, `PopAsync<T>(key, token)` and
   the rest — now live as extension methods on the new `CacheExtensions`, `HashCacheExtensions` and
   `SetCacheExtensions` static classes in the same `UiPath.Caching` namespace (`SetCacheExtensions`
-  ships in `UiPath.Caching.Queue`, alongside `ISetCache`). Call sites are unchanged and need no edit;
-  the interfaces shrink to just the policy-bearing members, so an implementation now has one member to
-  write per operation instead of one plus an inherited forwarder it could accidentally override.
+  ships in `UiPath.Caching.Queue`, alongside `ISetCache`). Production call sites are unchanged and need
+  no edit; the interfaces shrink to just the policy-bearing members, so an implementation now has one
+  member to write per operation instead of one plus an inherited forwarder it could accidentally
+  override. **Moq tests that mock the short forms do break, and not at compile time:** Moq reads the
+  `Setup`/`Verify` expression and refuses a call to a static method, so `GetAsync<T>(key, token)` or
+  `SetAsync(key, value, expiration, token)` inside one throws `NotSupportedException` when the test
+  runs. Re-target the setup at the member the extension forwards to, with `It.IsAny<CachePolicy>()` in
+  the new slot, since the extension passes `null` there. NSubstitute is unaffected: it records the call
+  the extension actually makes on the substitute, so `Returns` and `Received()` on the short form keep
+  working. See [Upgrading to 2.0](docs/upgrade-to-2.0.md#tests-that-mock-icache).
 - **BREAKING:** `ICacheOfT.Sync.cs`, `IHashCacheOfT.Sync.cs` and `ISetCacheOfT.Sync.cs` are gone the
   same way. The 59 blocking forwarders they carried as default interface methods — `Get`, `GetOrAdd`,
   `Set`, `TryAdd`, `Refresh`, `Remove`, `Contains`, `TimeToLive`, `ExpireTime`, the hash surface's
@@ -355,9 +362,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   now consistent with `GetHashCode` (the previous pairing could report two keys equal while hashing
   them into different buckets) and that keys built with `CacheKeyCasing.Sensitive` compare
   case-sensitively.
-- **`Microsoft.Extensions.*` dependency floor for `net10.0` raised to 10.0.11** (from 10.0.10).
-  The `net8.0` floor is unchanged at 8.0.x.
-- **OpenTelemetry packages moved to 1.18.0** (`OpenTelemetry.Instrumentation.StackExchangeRedis` to 1.18.0-beta.1).
+- **Dependency floors.** What a consumer's restore has to satisfy, taken from `Directory.Packages.props`
+  rather than from memory — an earlier draft of this entry said 10.0.11 and left StackExchange.Redis out:
+
+  | Package | 1.3.0 | 2.0.0 |
+  |---|---|---|
+  | `StackExchange.Redis` | 3.1.13 | 3.1.31 |
+  | `Microsoft.Extensions.*` (`net10.0` group) | 10.0.10 | 10.0.12 |
+  | `Microsoft.Extensions.Logging.Abstractions` (both TFMs) | 10.0.11 | 10.0.12 |
+
+  The `net8.0` group is unchanged at 8.0.x. `UiPath.Caching.OpenTelemetry` references no OpenTelemetry
+  package, so the 1.18.0 family this repository's samples moved to is a pin of the samples, not a floor
+  on consumers; `OpenTelemetry.Instrumentation.StackExchangeRedis` only needs to be a version without an
+  upper bound on StackExchange.Redis 3.x.
 - **BREAKING (source, not data):** every cache now serializes through `ISerializerProxy<byte[]>`.
   `RedisCache`, `RedisHashCache`, `RedisSetCache`, the memory set tier and all four providers take
   `ISerializerProxy<byte[]>` in place of `ISerializerProxy<RedisValue>`, and the broadcast change
@@ -366,7 +383,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   Consumers who pass these constructors a serializer directly, or who register a custom one, need a
   one-line type change; `AddCaching` now throws at startup if a leftover
   `ISerializerProxy<RedisValue>` registration is present, rather than ignoring it and silently
-  falling back to JSON.
+  falling back to JSON. The check runs whether or not `CacheOptions.Enabled` is set, so a disabled
+  test profile reports the same leftover the production profile would.
 - **Multi-key commands are checked against the Redis Cluster slot map before they run.** `GetAsync(CacheKey[])`, `GetCacheEntriesAsync`, the multi-key `SetAsync` and `RemoveAsync(CacheKey[])` each reach Redis as one command on one node, so a batch whose keys span slots is answered with an error, which the caches log and report as a miss: migrating an app onto a cluster turned a working batch read into a cache that never hits, with nothing thrown to say so. Each of those paths now compares the slots first and throws `CrossSlotKeysException`, naming the two keys that disagree and how to fix it. A non-clustered server maps every key to the same slot, so nothing changes off a cluster, and a disconnected cache skips the check and keeps answering from its own disconnected branch.
 - **`ShardKeyEnabled` leaves a key that already carries a hash tag alone.** The shard strategy used
   to wrap every key in braces, so a caller who had placed its own `{tag}` in the key ended up with
@@ -418,8 +436,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
   `PrimaryMaxExpirationDisconnected` and `UsePrimaryOnlyWhenDisconnected` on `IMultilayerCacheOptions`,
   `InMemoryCacheOptions` and `InMemoryRedisCacheOptions` — use `LocalMaxExpiration`,
   `LocalMaxExpirationDisconnected` and `UseLocalOnlyWhenDisconnected`, which they forwarded to — and
-  `RedisConnectionOptions.ThreadPoolSocketManager`, a no-op since StackExchange.Redis 3.0. Configuration
-  bound under the old keys is silently ignored by the binder, so rename those keys as well.
+  `RedisConnectionOptions.ThreadPoolSocketManager`, a no-op since StackExchange.Redis 3.0. The binder
+  skips a key it cannot place without a word, so a `PrimaryMaxExpiration` left in `appsettings.json`
+  would not fail the build, startup or a log line — the L1 cap would simply be gone. The section-bound
+  overloads (`AddMemory(sectionName)`, `AddInMemoryRedis(sectionName)`, `AddRedisConnection(sectionName)`
+  and the `(sectionName, configure)` form) therefore **throw `InvalidOperationException` at registration**
+  when one of the four removed keys is present under the section, naming the section, every offending key
+  and its replacement. The check runs whether or not the provider is enabled, since a disabled profile is
+  usually the non-production copy of one that is on elsewhere. The code-only overloads are not checked:
+  the property no longer exists to assign.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ flowchart LR
 | Topic | Doc |
 |---|---|
 | 5-minute onboarding | [docs/quickstart.md](docs/quickstart.md) |
+| Upgrading from 1.x to 2.0 | [docs/upgrade-to-2.0.md](docs/upgrade-to-2.0.md) |
 | Architecture & mental model | [docs/concepts.md](docs/concepts.md) |
 | Resilience (single-flight, hydrating, jitter, Polly) | [docs/how-to/resilience.md](docs/how-to/resilience.md) |
 | Broadcast (per-topic, notify doorbell, sharded Pub/Sub) | [docs/how-to/broadcast.md](docs/how-to/broadcast.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,8 @@ UiPath's internal multilayer caching library. L1 in-memory + L2 Redis, cross-nod
 
 **I'm new.** → [quickstart.md](quickstart.md). Five minutes from `dotnet add package` to `ICache<MyDto>` injected.
 
+**I'm on 1.x and moving to 2.0.** → [upgrade-to-2.0.md](upgrade-to-2.0.md). Every source, test and configuration change in one checklist, and what does not change (stored entries).
+
 **I'm building the mental model.** → [concepts.md](concepts.md). Architecture overview: providers, layers, topics, locks, policies, telemetry, and the two surfaces (`ICache<T>` vs `ICache`).
 
 **I need to solve X.**

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -43,6 +43,8 @@ Every binding-visible property on every shipped options class, with shipped defa
 
 ## Caching:Connections:Redis (RedisConnectionOptions)
 
+> `ThreadPoolSocketManager` was removed in 2.0 (a no-op since StackExchange.Redis 3.0). A section that still carries it fails `AddRedisConnection` at startup; delete the key. See [Upgrading to 2.0](../upgrade-to-2.0.md#configuration-keys).
+
 | Property | Type | Default | Scope | Notes |
 |---|---|---|---|---|
 | `ConnectionString` | `string` | _required_ | App-wide | StackExchange.Redis connection string; apps fail at startup without a valid value. Use `"localhost:6379"` as a local placeholder. |
@@ -138,6 +140,8 @@ Per-topic overrides: add entries to `Topics[]` under `Broadcast:RedisPubSub`. Ea
 
 ## Caching:InMemoryRedis (InMemoryRedisCacheOptions)
 
+> The 1.x aliases `PrimaryMaxExpiration`, `PrimaryMaxExpirationDisconnected` and `UsePrimaryOnlyWhenDisconnected` were removed in 2.0. A section that still carries one fails `AddInMemoryRedis` at startup; rename to the `Local*` keys below. See [Upgrading to 2.0](../upgrade-to-2.0.md#configuration-keys).
+
 | Property | Type | Default | Scope | Notes |
 |---|---|---|---|---|
 | `Enabled` | `bool` | `true` | Per-provider | Enable/disable this two-tier (L1 in-memory + L2 Redis) cache provider. |
@@ -183,6 +187,8 @@ Per-topic overrides: add entries to `Topics[]` under `Broadcast:RedisPubSub`. Ea
 ---
 
 ## Caching:InMemory (InMemoryCacheOptions)
+
+> The 1.x aliases `PrimaryMaxExpiration`, `PrimaryMaxExpirationDisconnected` and `UsePrimaryOnlyWhenDisconnected` were removed in 2.0. A section that still carries one fails `AddMemory` at startup; rename to the `Local*` keys below. See [Upgrading to 2.0](../upgrade-to-2.0.md#configuration-keys).
 
 | Property | Type | Default | Scope | Notes |
 |---|---|---|---|---|

--- a/docs/upgrade-to-2.0.md
+++ b/docs/upgrade-to-2.0.md
@@ -1,0 +1,237 @@
+# Upgrading from 1.x to 2.0
+
+2.0 changes source, tests and configuration. It does not change a stored byte: the default
+serializer writes what 1.x wrote, so mixed-version pods during a rollout read each other's entries
+and a rollback is a package revert. The one exception is where the key is rendered, not the value:
+a deployment running `ShardKeyEnabled: true` with braces in its cache keys addresses different Redis
+keys on 1.3 and 2.0, see [Configuration keys](#configuration-keys).
+
+Work through the sections in order. Each says how the break shows itself, because several of them
+do not show at compile time.
+
+| Section | Shows itself as |
+|---|---|
+| [Packages and floors](#packages-and-floors) | `NU1605` / `NU1608` on restore |
+| [Configuration keys](#configuration-keys) | `InvalidOperationException` at startup (silent in 2.0.0-preview.2 and earlier) |
+| [Serializer registration](#serializer-registration) | `InvalidOperationException` at startup |
+| [Per-call expiration](#per-call-expiration) | Compile error, then `ArgumentOutOfRangeException` for a zero or past value |
+| [Tests that mock ICache](#tests-that-mock-icache) | `NotSupportedException` when the test runs |
+| [Hand-written implementations](#hand-written-implementations) | Compile error |
+| [Clock](#clock) | Compile error, or a test clock that stops being honored |
+| [Renamed types](#renamed-types) | Compile error |
+| [Integrations built against 1.x](#integrations-built-against-1x) | No compile or restore signal; `MissingMethodException` / `TypeLoadException` at the first call to a removed member |
+
+## Packages and floors
+
+Move every `UiPath.Caching.*` reference to the same 2.0 version. The floors a consumer's own
+references must clear, from `Directory.Packages.props`:
+
+| Package | 1.3.0 | 2.0.0 |
+|---|---|---|
+| `StackExchange.Redis` | 3.1.13 | 3.1.31 |
+| `Microsoft.Extensions.*` on `net10.0` | 10.0.10 | 10.0.12 |
+| `Microsoft.Extensions.Logging.Abstractions` on either TFM | 10.0.11 | 10.0.12 |
+
+A project that pins any of these lower than the floor fails restore with `NU1605`. Raise the pin;
+the library declares the floor, not a ceiling. `OpenTelemetry.Instrumentation.StackExchangeRedis` is
+pinned in this repository for its own sample and tests, and is not a floor on consumers: any version
+that does not cap StackExchange.Redis below 3.x works.
+
+## Configuration keys
+
+Four options keys were `[Obsolete]` in 1.x and are gone in 2.0: three multilayer rename aliases
+that forwarded to the `Local*` properties, and `ThreadPoolSocketManager`, a no-op since
+StackExchange.Redis 3.0 with nothing to forward to. The configuration binder ignores a key it cannot
+place, so a leftover key does not fail the build or write a log line; the value falls back to its
+default. For `PrimaryMaxExpiration` that means the L1 cap disappears.
+
+| Section | Remove | Use |
+|---|---|---|
+| `Caching:InMemoryRedis`, `Caching:InMemory` | `PrimaryMaxExpiration` | `LocalMaxExpiration` |
+| `Caching:InMemoryRedis`, `Caching:InMemory` | `PrimaryMaxExpirationDisconnected` | `LocalMaxExpirationDisconnected` |
+| `Caching:InMemoryRedis`, `Caching:InMemory` | `UsePrimaryOnlyWhenDisconnected` | `UseLocalOnlyWhenDisconnected` |
+| `Caching:Connections:Redis` | `ThreadPoolSocketManager` | nothing; it has been a no-op since StackExchange.Redis 3.0 |
+
+From 2.0.0 final, the section-bound registrations refuse a section that still carries one of these
+and name the key and its replacement in the exception. That covers `appsettings.json`, environment
+variables and any other provider bound through `AddMemory()`, `AddInMemoryRedis()` and
+`AddRedisConnection()`. Keys that were never read by any options class are not detected: check the
+section against [settings.md](reference/settings.md) while you are in the file.
+
+```diff
+ "InMemoryRedis": {
+-  "PrimaryMaxExpiration": "01:00:00"
++  "LocalMaxExpiration":   "01:00:00"
+ }
+```
+
+`CacheOptions.ShardKeyEnabled` is deprecated, not removed. Leave it as it is: flipping it relocates
+every brace-free key. If it is `true` *and* your keys contain braces, 2.0 renders them differently:
+1.3 wrapped the whole key in a new `{...}`, 2.0 keeps a valid caller-supplied `{tag}` as the tag and
+refuses a key whose braces form no valid tag. Those entries live under a different Redis key on each
+version, so a mixed rollout misses across versions and a rollback re-misses; a brace-free key, or
+`ShardKeyEnabled: false`, renders identically on both.
+
+## Serializer registration
+
+`ISerializerProxy<RedisValue>` is gone. Every cache serializes through `ISerializerProxy<byte[]>`,
+and the default `SystemJsonByteSerializerProxy` writes the same bytes `SystemJsonSerializerProxy`
+wrote, so no entry moves.
+
+If you register your own serializer, change the interface and the registration:
+
+```diff
+-public class SerializerProxy : ISerializerProxy<RedisValue>
++public class SerializerProxy : IMemorySerializerProxy
+ {
+-    public T? Deserialize<T>(RedisValue value) => ...;
+-    public RedisValue Serialize(object? value) => ...;
++    public T? Deserialize<T>(byte[]? value) => ...;
++    public byte[]? Serialize(object? value) => ...;
++    public ReadOnlyMemory<byte> SerializeToMemory<T>(T? value) => ...;
+ }
+
+-services.AddSingleton<ISerializerProxy<RedisValue>, SerializerProxy>();
++services.AddSingleton<ISerializerProxy<byte[]>, SerializerProxy>();
+```
+
+Implement `IMemorySerializerProxy` rather than the plain `ISerializerProxy<byte[]>` when your
+serializer already produces a `Memory<byte>`. `RedisCache` and `RedisHashCache` test for that
+interface and call `SerializeToMemory` when it is there; with the plain interface every write first
+copies the payload into an array. The memory is borrowed and is only read until the write completes,
+so a pooled buffer is safe. Details in
+[extending.md](how-to/extending.md#lending-memory-imemoryserializerproxy).
+
+A leftover `ISerializerProxy<RedisValue>` registration that is already in the container when
+`AddCaching` runs fails it rather than being ignored, whether or not caching is enabled in that
+profile. The scan happens once, inside `AddCaching`, so a legacy registration added after it is not
+seen and stays silently unused: replace every one, and register the serializer before `AddCaching`. `RawByteSerializerProxy` is also
+available and is a wire-format change; do not switch to it during the upgrade.
+
+## Per-call expiration
+
+The `expiration` parameter is `TimeSpan` / `DateTimeOffset`, not nullable. Passing `null` meant
+the same as not passing it, and made `SetAsync(key, value, null)` ambiguous between the two nullable
+overloads. A caller that forwards its own optional value now branches:
+
+```diff
+-return await cache.SetAsync(key, value, options?.AbsoluteExpirationRelativeToNow, token);
++var expiration = options?.AbsoluteExpirationRelativeToNow;
++return expiration.HasValue
++    ? await cache.SetAsync(key, value, expiration.Value, token)
++    : await cache.SetAsync(key, value, token);
+```
+
+The overload without an expiration resolves `CachePolicy.DistributedExpiration`, then the
+provider's `DefaultExpiration`, then a one-hour floor. That floor is new: in 1.x a provider whose
+`DefaultExpiration` was `null` wrote entries with no TTL. To keep an entry until it is removed, name
+`TimeSpan.MaxValue` explicitly.
+
+A value that is passed is enforced by every real provider. A `TimeSpan` that is zero or negative,
+or a `DateTimeOffset` already in the past, throws `ArgumentOutOfRangeException` and writes nothing.
+In 1.x the same value meant "no expiration". `NullCache`, `NullHashCache` and `NullSetCache` read no
+argument and enforce nothing, so a service running with caching disabled, or resolving a provider
+that is absent, will not see the throw in a test environment and meet it first in production. Search
+your configuration for durations of `0` or `00:00:00` that feed a per-call expiration; a catch-all
+around the write turns the throw into a skipped write and a log line, which is easy to miss.
+
+## Tests that mock ICache
+
+The short forms, `GetAsync<T>(key, token)`, `SetAsync(key, value, expiration, token)` and the
+rest, moved off the interface onto `CacheExtensions`, `HashCacheExtensions` and
+`SetCacheExtensions`. Production code compiles unchanged. A Moq setup does not: Moq reads the
+`Setup` or `Verify` expression and refuses a call to a static method, so a short form inside one
+throws `NotSupportedException` when the test runs, not when it builds.
+
+Re-target the setup at the member the extension forwards to. The extension passes `null` in the new
+`policy` slot, so match it loosely:
+
+```diff
+-_cache.Setup(x => x.GetAsync<string>(key, It.IsAny<CancellationToken>()))
++_cache.Setup(x => x.GetAsync<string>((CacheKey)key, It.IsAny<CachePolicy>(), It.IsAny<CancellationToken>()))
+     .ReturnsAsync(value);
+
+-_cache.Setup(x => x.SetAsync(key, value, expiration, It.IsAny<CancellationToken>()))
++_cache.Setup(x => x.SetAsync<string>((CacheKey)key, value, expiration, It.IsAny<CachePolicy>(), It.IsAny<CancellationToken>()))
+     .ReturnsAsync(true);
+```
+
+If a test asserts the expiration-free path, set up the overload with no `expiration` parameter; the
+two are distinct members now and a `VerifyAll` on the wrong one fails.
+
+NSubstitute is unaffected. Calling the short form on a substitute runs the extension, which calls
+the policy-bearing member on the substitute, and that is the call `Returns` and `Received()` record.
+Existing NSubstitute tests keep working as written.
+
+The blocking forwarders (`Get`, `Set`, `GetOrAdd` and the rest on `ICache<T>`) moved the same way,
+to `CacheSyncExtensions` and siblings, with the same consequence for mocks.
+
+## Hand-written implementations
+
+Fakes and adapters that implement `ICache`, `ICache<T>`, `IHashCache` or `ISetCache` directly need
+three kinds of edit:
+
+- **`TryAddAsync`** is a required member on `ICache` and `ICache<T>`, with three overloads. A fake
+  can return `false` (fail-closed) or delegate to a dictionary's `TryAdd`.
+- **`policy` is a required parameter** on every member that takes one; the `= null` default is gone.
+  Drop the default from the implementation too, so a call through the concrete type behaves like one
+  through the interface.
+- **The compat and sync forwarders are gone from the interfaces.** An explicit interface
+  implementation of one, `ValueTask<T?> ICache.GetAsync<T>(CacheKey, CancellationToken)` say, no
+  longer compiles, because the member is not on the interface; delete it. A public method of the same
+  shape still compiles, but nothing reaches it through the interface any more, so callers going
+  through `ICache` land on the extension and then on your policy-bearing member instead.
+
+The cache and provider constructors take `ISerializerProxy<byte[]>` and a `TimeProvider`; see
+[Clock](#clock).
+
+## Clock
+
+`CacheClock`, `ISystemClock` and the per-options `Clock` properties are gone. `System.TimeProvider`
+is the single clock: `AddCaching` registers `TimeProvider.System` unless the container already has
+one. A test that registered an `ISystemClock` to control time is no longer honored and silently runs
+on the wall clock; register a `TimeProvider` before `AddCaching` instead. The conversion from a
+lifetime to a deadline is `TimeProvider.ToDateTimeOffset(...)` in the abstractions package, and it
+saturates at `DateTimeOffset.MaxValue` instead of overflowing.
+
+`GetCacheEntryAsync` on a key with no TTL reports an `Expiration` of `DateTimeOffset.MaxValue` rather
+than `now + DefaultExpiration`; `TimeToLiveAsync` and `ExpireTimeAsync` return `null` for the same
+key, as they did in 1.x, so the two surfaces now agree that no deadline exists. The fabricated
+deadline also acted as a hidden L1 cap in 1.x: the local copy of a no-TTL key turned
+over every `DefaultExpiration`. It now lives until a broadcast invalidation or `LocalMaxExpiration`
+evicts it, so set `LocalMaxExpiration` if you were relying on the turnover.
+
+## Renamed types
+
+| 1.x | 2.0 |
+|---|---|
+| `RedisTypePrefixes` | `RedisKeyspaces` (same constant values; no key moves) |
+| `SystemJsonSerializerProxy` | `SystemJsonByteSerializerProxy` (same bytes) |
+| `IEventFormatterProxy<T>.Decode(string)` / `EncodeAsString(T)` | `Decode(ReadOnlyMemory<byte>)` / `Encode(T)` |
+
+`CacheKey.Equals` and `GetHashCode` are ordinal. Insensitive keys are lowercased at construction,
+so nothing changes for them; keys built with `CacheKeyCasing.Sensitive` now compare
+case-sensitively, which is what the mode says.
+
+## Integrations built against 1.x
+
+A package compiled against `UiPath.Caching` 1.3.0 still loads against 2.0, because .NET accepts a
+higher assembly version than the one referenced. Loading is not working: every member the **Removed**
+and **BREAKING** entries name is gone or has a new signature, and a 1.3 binary that touches one fails
+at the first call with `MissingMethodException` or `TypeLoadException`, with no compile error on your
+side. Which members a given integration touches is something only its source can answer. The
+telemetry and profiler seams, `ICachingTelemetryProvider`, `ITelemetryOperation`, `ICachingBuilder`,
+`IRedisProfiler` and the `RedisConnectionOptions` members a profiler reads, have no binary change
+since 1.3.0, so an integration confined to those runs. That is a fact about 2.0.0, not a promise.
+
+Prefer a build of the integration against 2.0 when one exists. Where the integration is a telemetry
+bridge, `UiPath.Caching.OpenTelemetry` is the supported replacement and removes the skew entirely.
+Until then, watch for those two exception types naming `UiPath.Caching` in the first minutes after a
+deploy, and confirm cache hit and miss telemetry still arrives.
+
+## Rollback
+
+Reverting the package is enough for stored data: 2.0 writes what 1.3 wrote, under the same key
+unless the `ShardKeyEnabled` case above applies. Code that adopted the
+non-nullable expiration, the byte-array serializer seam or the re-targeted mocks does not compile
+against 1.3, so a rollback of the binary is a rollback of the branch, not only of the version line.

--- a/src/UiPath.Caching/Config/CachingBuilder.cs
+++ b/src/UiPath.Caching/Config/CachingBuilder.cs
@@ -34,19 +34,25 @@ public class CachingBuilder(IServiceCollection services, IConfiguration? configu
         Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<CacheOptions>, ReservedRedisKeyspaceValidator>());
 
+        if (Enabled)
+        {
+            foreach (var callback in _callbacks)
+            {
+                callback(this);
+            }
+        }
+
+        // After the callbacks, which may register services, and before the switch: a disabled profile is
+        // usually the test copy of one that is on, and should report the same dead registration.
+        ThrowIfLegacySerializerRegistered();
+
         if(!Enabled)
         {
             return;
         }
 
-        foreach (var callback in _callbacks)
-        {
-            callback(this);
-        }
-
         Services.TryAddEnumerable(
             ServiceDescriptor.Singleton<IValidateOptions<CacheOptions>, CacheKeyCasingSeeder>());
-        ThrowIfLegacySerializerRegistered();
         Services.TryAddSingleton<ISerializerProxy<byte[]>>(sp => new SystemJsonByteSerializerProxy(sp.GetService<JsonSerializerOptions>()));
         Services.TryAddSingleton<IResiliencePipelineProvider>(EmptyResiliencePipelineProvider.Instance);
         Services.TryAddSingleton<IChangeTokenFactory>(NullChangeTokenFactory.Instance);

--- a/src/UiPath.Caching/Config/InMemoryCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/InMemoryCollectionExtensions.cs
@@ -3,8 +3,12 @@ namespace UiPath.Caching.Config;
 [ExcludeFromCodeCoverage]
 public static class InMemoryCollectionExtensions
 {
-    public static ICachingBuilder AddMemory(this ICachingBuilder builder, string sectionName = KnownCacheProviderNames.InMemory) =>
-        builder.AddMemory(opt => builder.Configuration.GetSection(sectionName).Bind(opt));
+    public static ICachingBuilder AddMemory(this ICachingBuilder builder, string sectionName = KnownCacheProviderNames.InMemory)
+    {
+        var section = builder.Configuration.GetSection(sectionName);
+        RemovedConfigurationKeys.ThrowIfPresent(section, RemovedConfigurationKeys.Multilayer);
+        return builder.AddMemory(opt => section.Bind(opt));
+    }
 
     public static ICachingBuilder AddMemory(this ICachingBuilder builder, Action<InMemoryCacheOptions> configure)
     {

--- a/src/UiPath.Caching/Config/InMemoryRedisCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/InMemoryRedisCollectionExtensions.cs
@@ -3,8 +3,12 @@ namespace UiPath.Caching.Config;
 [ExcludeFromCodeCoverage]
 public static class InMemoryRedisCollectionExtensions
 {
-    public static ICachingBuilder AddInMemoryRedis(this ICachingBuilder builder, string sectionName = KnownCacheProviderNames.InMemoryRedis) =>
-        builder.AddInMemoryRedis(opt => builder.Configuration.GetSection(sectionName).Bind(opt));
+    public static ICachingBuilder AddInMemoryRedis(this ICachingBuilder builder, string sectionName = KnownCacheProviderNames.InMemoryRedis)
+    {
+        var section = builder.Configuration.GetSection(sectionName);
+        RemovedConfigurationKeys.ThrowIfPresent(section, RemovedConfigurationKeys.Multilayer);
+        return builder.AddInMemoryRedis(opt => section.Bind(opt));
+    }
 
     public static ICachingBuilder AddInMemoryRedis(this ICachingBuilder builder, Action<InMemoryRedisCacheOptions> configure)
     {

--- a/src/UiPath.Caching/Config/RedisCollectionExtensions.cs
+++ b/src/UiPath.Caching/Config/RedisCollectionExtensions.cs
@@ -25,8 +25,12 @@ public static class RedisCollectionExtensions
         return builder;
     }
 
-    public static ICachingBuilder AddRedisConnection(this ICachingBuilder builder, string sectionName = Connections) =>
-        builder.AddRedisConnection(opt => builder.Configuration.GetSection(sectionName).Bind(opt));
+    public static ICachingBuilder AddRedisConnection(this ICachingBuilder builder, string sectionName = Connections)
+    {
+        var section = builder.Configuration.GetSection(sectionName);
+        RemovedConfigurationKeys.ThrowIfPresent(section, RemovedConfigurationKeys.RedisConnection);
+        return builder.AddRedisConnection(opt => section.Bind(opt));
+    }
 
     public static ICachingBuilder AddRedisConnection(this ICachingBuilder builder, Action<RedisConnectionOptions> configure)
     {
@@ -38,6 +42,8 @@ public static class RedisCollectionExtensions
 
     public static ICachingBuilder AddRedisConnection(this ICachingBuilder builder, string sectionName, Action<RedisConnectionOptions> configure)
     {
+        RemovedConfigurationKeys.ThrowIfPresent(builder.Configuration.GetSection(sectionName), RemovedConfigurationKeys.RedisConnection);
+
         void ConfigureOptions(RedisConnectionOptions opt)
         {
             builder.Configuration.GetSection(sectionName).Bind(opt);

--- a/src/UiPath.Caching/Config/RemovedConfigurationKeys.cs
+++ b/src/UiPath.Caching/Config/RemovedConfigurationKeys.cs
@@ -1,0 +1,53 @@
+namespace UiPath.Caching.Config;
+
+/// <summary>
+/// Refuses configuration still written under an options key 2.0 removed. The binder skips a key it
+/// cannot place without a word, so a leftover alias would quietly turn into the default: an L1 cap
+/// gone, not renamed.
+/// </summary>
+internal static class RemovedConfigurationKeys
+{
+    internal static readonly IReadOnlyList<(string Old, string? New)> Multilayer =
+    [
+        ("PrimaryMaxExpiration", "LocalMaxExpiration"),
+        ("PrimaryMaxExpirationDisconnected", "LocalMaxExpirationDisconnected"),
+        ("UsePrimaryOnlyWhenDisconnected", "UseLocalOnlyWhenDisconnected"),
+    ];
+
+    internal static readonly IReadOnlyList<(string Old, string? New)> RedisConnection =
+    [
+        ("ThreadPoolSocketManager", null),
+    ];
+
+    /// <exception cref="InvalidOperationException">A removed key is present under <paramref name="section"/>.</exception>
+    internal static void ThrowIfPresent(IConfigurationSection section, IReadOnlyList<(string Old, string? New)> removed)
+    {
+        // The children are enumerated rather than probed with Exists(), which is false for a key whose
+        // value is null. JSON keeps "Key": null as a key with no value, and in 1.x binding that null was
+        // how a caller removed the default cap, so it has to be caught too.
+        var present = new HashSet<string>(section.GetChildren().Select(c => c.Key), StringComparer.OrdinalIgnoreCase);
+        List<string>? found = null;
+        foreach (var (old, replacement) in removed)
+        {
+            if (!present.Contains(old))
+            {
+                continue;
+            }
+
+            found ??= [];
+            found.Add(replacement is null
+                ? $"'{old}' was removed and has no effect; delete it"
+                : $"'{old}' was renamed; use '{replacement}'");
+        }
+
+        if (found is null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Configuration section '{section.Path}' uses keys that UiPath.Caching 2.0 removed. The binder would " +
+            $"ignore them without error, so the values would silently fall back to their defaults: " +
+            string.Join("; ", found) + ".");
+    }
+}

--- a/tests/UiPath.Caching.Tests/CachingBuilderTests.cs
+++ b/tests/UiPath.Caching.Tests/CachingBuilderTests.cs
@@ -23,6 +23,31 @@ public class CachingBuilderTests
     }
 
     [Fact]
+    public void A_leftover_RedisValue_serializer_registration_fails_the_build_even_when_caching_is_disabled()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Substitute.For<ISerializerProxy<RedisValue>>());
+
+        var act = () => new CachingBuilder(services) { Enabled = false }.Complete();
+
+        act.Should().Throw<InvalidOperationException>("a disabled profile is usually the test copy of one that is on elsewhere")
+            .WithMessage("*ISerializerProxy<RedisValue>*");
+    }
+
+    [Fact]
+    public void A_RedisValue_serializer_registered_by_a_completion_callback_fails_the_build()
+    {
+        var builder = new CachingBuilder(new ServiceCollection());
+        builder.RegisterOnCompleteCallback(typeof(CachingBuilderTests),
+            b => b.Services.AddSingleton(Substitute.For<ISerializerProxy<RedisValue>>()));
+
+        var act = () => builder.Complete();
+
+        act.Should().Throw<InvalidOperationException>("callbacks run before the check, so what they register is seen")
+            .WithMessage("*ISerializerProxy<RedisValue>*");
+    }
+
+    [Fact]
     public void A_byte_serializer_registration_is_honored_over_the_default()
     {
         var services = new ServiceCollection();

--- a/tests/UiPath.Caching.Tests/Config/RemovedConfigurationKeysTests.cs
+++ b/tests/UiPath.Caching.Tests/Config/RemovedConfigurationKeysTests.cs
@@ -1,0 +1,143 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using UiPath.Caching.Config;
+
+namespace UiPath.Caching.Tests.Config;
+
+public class RemovedConfigurationKeysTests
+{
+    [Theory]
+    [InlineData("PrimaryMaxExpiration", "LocalMaxExpiration")]
+    [InlineData("PrimaryMaxExpirationDisconnected", "LocalMaxExpirationDisconnected")]
+    [InlineData("UsePrimaryOnlyWhenDisconnected", "UseLocalOnlyWhenDisconnected")]
+    public void AddInMemoryRedis_from_configuration_throws_on_a_renamed_key(string old, string replacement)
+    {
+        var act = () => Register(b => b.AddInMemoryRedis(), $"Caching:InMemoryRedis:{old}", "01:00:00");
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("Caching:InMemoryRedis").And.Contain(old).And.Contain(replacement);
+    }
+
+    [Theory]
+    [InlineData("PrimaryMaxExpiration", "LocalMaxExpiration")]
+    [InlineData("PrimaryMaxExpirationDisconnected", "LocalMaxExpirationDisconnected")]
+    [InlineData("UsePrimaryOnlyWhenDisconnected", "UseLocalOnlyWhenDisconnected")]
+    public void AddMemory_from_configuration_throws_on_a_renamed_key(string old, string replacement)
+    {
+        var act = () => Register(b => b.AddMemory(), $"Caching:InMemory:{old}", "01:00:00");
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("Caching:InMemory").And.Contain(old).And.Contain(replacement);
+    }
+
+    [Fact]
+    public void AddRedisConnection_from_configuration_throws_on_the_removed_socket_manager_key()
+    {
+        var act = () => Register(b => b.AddRedisConnection(), "Caching:Connections:Redis:ThreadPoolSocketManager", "true");
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("Caching:Connections:Redis").And.Contain("ThreadPoolSocketManager").And.Contain("delete it");
+    }
+
+    [Fact]
+    public void AddRedisConnection_with_section_and_configure_throws_on_the_removed_socket_manager_key()
+    {
+        var act = () => Register(
+            b => b.AddRedisConnection("Connections:Redis", _ => { }),
+            "Caching:Connections:Redis:ThreadPoolSocketManager",
+            "false");
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("ThreadPoolSocketManager");
+    }
+
+    [Fact]
+    public void A_removed_key_with_a_null_value_is_refused()
+    {
+        // JSON "PrimaryMaxExpiration": null reaches the binder as a key with no value; in 1.x that null
+        // removed the default cap, so it must not pass as absent.
+        var act = () => Register(b => b.AddInMemoryRedis(), ("Caching:InMemoryRedis:PrimaryMaxExpiration", null));
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("PrimaryMaxExpiration");
+    }
+
+    [Fact]
+    public void A_removed_key_is_matched_regardless_of_case()
+    {
+        var act = () => Register(b => b.AddInMemoryRedis(), ("Caching:InMemoryRedis:primarymaxexpiration", "01:00:00"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("PrimaryMaxExpiration");
+    }
+
+    [Fact]
+    public void A_removed_key_is_refused_even_when_the_provider_is_disabled()
+    {
+        var act = () => Register(b => b.AddInMemoryRedis(),
+            ("Caching:InMemoryRedis:Enabled", "false"),
+            ("Caching:InMemoryRedis:PrimaryMaxExpiration", "01:00:00"));
+
+        act.Should().Throw<InvalidOperationException>("a disabled provider is often the non-production profile of one that is on elsewhere");
+    }
+
+    [Fact]
+    public void Every_removed_key_present_is_named_in_one_message()
+    {
+        var act = () => Register(b => b.AddInMemoryRedis(),
+            ("Caching:InMemoryRedis:PrimaryMaxExpiration", "01:00:00"),
+            ("Caching:InMemoryRedis:UsePrimaryOnlyWhenDisconnected", "true"));
+
+        act.Should().Throw<InvalidOperationException>()
+            .Which.Message.Should().Contain("PrimaryMaxExpiration").And.Contain("UsePrimaryOnlyWhenDisconnected");
+    }
+
+    [Fact]
+    public void The_renamed_keys_bind_without_complaint()
+    {
+        using var provider = Register(b => b.AddInMemoryRedis(),
+            ("Caching:InMemoryRedis:LocalMaxExpiration", "01:00:00"),
+            ("Caching:InMemoryRedis:LocalMaxExpirationDisconnected", "00:00:10"),
+            ("Caching:InMemoryRedis:UseLocalOnlyWhenDisconnected", "true"));
+
+        var options = provider.GetRequiredService<IOptions<InMemoryRedisCacheOptions>>().Value;
+        options.LocalMaxExpiration.Should().Be(TimeSpan.FromHours(1));
+        options.LocalMaxExpirationDisconnected.Should().Be(TimeSpan.FromSeconds(10));
+        options.UseLocalOnlyWhenDisconnected.Should().BeTrue();
+    }
+
+    [Fact]
+    public void A_section_with_no_removed_key_is_left_alone()
+    {
+        using var provider = Register(b => b.AddInMemoryRedis().AddRedisConnection(),
+            ("Caching:InMemoryRedis:DefaultExpiration", "00:05:00"),
+            ("Caching:Connections:Redis:ProfilerEnabled", "false"));
+
+        provider.GetRequiredService<IOptions<InMemoryRedisCacheOptions>>().Value.DefaultExpiration
+            .Should().Be(TimeSpan.FromMinutes(5));
+    }
+
+    [Fact]
+    public void The_code_only_overloads_are_not_guarded_because_the_compiler_already_is()
+    {
+        // No configuration at all: nothing to scan, and the property no longer exists to assign.
+        var act = () => Register(b => b.AddInMemoryRedis(opt => opt.LocalMaxExpiration = TimeSpan.FromHours(1)));
+
+        act.Should().NotThrow();
+    }
+
+    private static ServiceProvider Register(Action<ICachingBuilder> configure, string key, string value) =>
+        Register(configure, (key, value));
+
+    private static ServiceProvider Register(Action<ICachingBuilder> configure, params (string Key, string? Value)[] values)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(values.ToDictionary(v => v.Key, v => v.Value))
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddCaching(configuration, configure);
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## Summary

The first consumer to move onto 2.0.0-preview.2 (Cloud-RPA #27279) nearly shipped with its L1 cap silently gone: the binder ignores a `PrimaryMaxExpiration` it can no longer place, and nothing in the build, at startup or in the logs said so. This makes the library refuse the four keys 2.0 removed, corrects the changelog where that upgrade found it wrong, and adds the migration guide the PR author had to write themselves.

## Changes

- **Removed config keys throw at registration.** `AddMemory(sectionName)`, `AddInMemoryRedis(sectionName)` and both section-bound `AddRedisConnection` overloads fail with `InvalidOperationException` when `PrimaryMaxExpiration`, `PrimaryMaxExpirationDisconnected`, `UsePrimaryOnlyWhenDisconnected` or `ThreadPoolSocketManager` is present under the section, naming the section, every offending key and its replacement. Runs whether or not the provider is enabled. Code-only overloads are not checked: the property no longer exists to assign. The existing leftover-`ISerializerProxy<RedisValue>` guard now runs on the same terms, before the `Enabled` switch, so a disabled test profile reports it too. No public API change.
- **Changelog floors corrected.** The entry said Microsoft.Extensions 10.0.11 and omitted StackExchange.Redis; it is now a table from `Directory.Packages.props` (SE.Redis 3.1.13 → 3.1.31, Microsoft.Extensions 10.0.10 → 10.0.12, Logging.Abstractions 10.0.11 → 10.0.12, OpenTelemetry 1.17.0 → 1.18.0).
- **Changelog compat entry corrected.** "Call sites are unchanged" holds for production code only. Moq inspects the `Setup`/`Verify` expression and refuses a static call, so a short form inside one throws `NotSupportedException` at test run time. The entry now says so and shows the re-targeting with an any-policy matcher. NSubstitute is unaffected and the entry says that too.
- **New `docs/upgrade-to-2.0.md`**, linked from the docs index and README. Opens with how each break shows itself (three do not show at compile time), then covers floors, config keys, the serializer seam and `IMemorySerializerProxy`, the nullable-expiration branch and the throw on zero or past values, mocking, hand-written implementations, the clock, renamed types, the binary-compat position for integrations built against 1.x, and rollback.
- `settings.md` gains a one-line pointer above each of the three affected sections.

## Test plan

- [x] Unit tests added/updated — `RemovedConfigurationKeysTests`: each renamed key on both multilayer sections, the socket-manager key on both connection overloads, disabled provider still refused, all offending keys in one message, renamed keys bind cleanly, unrelated sections untouched, code-only overload not guarded.
- [x] Full suite passes locally on net10.0 (1734 passed, 0 failed, 12 skipped); the new class also passes on net8.0.
- [x] CHANGELOG.md updated

## Linked issues

Prompted by UiPath/Cloud-RPA#27279.

## Contributor declaration

- [x] I signed off my commits per the [DCO](https://github.com/UiPath/dotnet-caching/blob/main/CONTRIBUTING.md#sign-off-dco) (`git commit -s`).
- [x] I am contributing **on behalf of my employer**, or in the course of employment / using employer resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

